### PR TITLE
Implement league rosters tab

### DIFF
--- a/frontend/src/api/useRosters.ts
+++ b/frontend/src/api/useRosters.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { FantasyTeamRoster } from "@/types/FantasyTeamRoster";
+
+export const useRosters = (leagueId: string | undefined) =>
+  useQuery<FantasyTeamRoster[]>({
+    queryFn: () =>
+      fetch(`/api/leagues/${leagueId}/rosters`).then((res) => res.json()),
+    queryKey: ["leagueRosters", leagueId],
+    enabled: !!leagueId,
+  });

--- a/frontend/src/components/Rosters.js
+++ b/frontend/src/components/Rosters.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Card, CardContent, CardHeader } from './ui/card';
+import { useRosters } from '@/api/useRosters';
+import { useLeague } from '@/api/useLeague';
+import { useTeamAvatar } from '@/api/useTeamAvatar';
+
+const RosterTeamCard = ({ teamKey, year }) => {
+  const teamNumber = teamKey.replace('frc', '');
+  const teamAvatar = useTeamAvatar(teamKey, year);
+
+  return (
+    <a
+      href={`https://www.thebluealliance.com/team/${teamNumber}/${year}`}
+      target="_blank"
+      className="p-2 border rounded-xl h-16 flex flex-col relative bg-slate-700 hover:bg-slate-800 cursor-pointer text-start"
+    >
+      <p className="text-xl font-bold">{teamNumber}</p>
+      {teamAvatar.data?.image && (
+        <img
+          src={`data:image/png;base64,${teamAvatar.data.image}`}
+          className="aspect-square h-1/2 absolute bottom-0 right-0 rounded"
+        />
+      )}
+    </a>
+  );
+};
+
+const Rosters = ({ leagueId }) => {
+  const rosters = useRosters(leagueId);
+  const league = useLeague(leagueId);
+
+  if (rosters.isLoading || league.isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {rosters.data?.map((team) => (
+        <Card key={team.fantasy_team_id}>
+          <CardHeader>{team.fantasy_team_name}</CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-3 gap-2">
+              {team.roster.map((r) => (
+                <RosterTeamCard key={r} teamKey={r} year={league.data?.year} />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default Rosters;

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Route as rootRoute } from './routes/__root'
 import { Route as LeaguesLeagueIdImport } from './routes/leagues/$leagueId'
 import { Route as DraftsDraftIdImport } from './routes/drafts/_.$draftId'
+import { Route as LeaguesLeagueIdRostersLazyImport } from './routes/leagues/$leagueId/rosters.lazy'
 
 // Create Virtual Routes
 
@@ -24,6 +25,9 @@ const LeaguesLeagueIdScoresLazyImport = createFileRoute(
 )()
 const LeaguesLeagueIdRankingsLazyImport = createFileRoute(
   '/leagues/$leagueId/rankings',
+)()
+const LeaguesLeagueIdRostersLazyImport = createFileRoute(
+  '/leagues/$leagueId/rosters',
 )()
 
 // Create/Update Routes
@@ -51,6 +55,14 @@ const LeaguesLeagueIdRankingsLazyRoute =
     getParentRoute: () => LeaguesLeagueIdRoute,
   } as any).lazy(() =>
     import('./routes/leagues/$leagueId/rankings.lazy').then((d) => d.Route),
+  )
+
+const LeaguesLeagueIdRostersLazyRoute =
+  LeaguesLeagueIdRostersLazyImport.update({
+    path: '/rosters',
+    getParentRoute: () => LeaguesLeagueIdRoute,
+  } as any).lazy(() =>
+    import('./routes/leagues/$leagueId/rosters.lazy').then((d) => d.Route),
   )
 
 const DraftsDraftIdRoute = DraftsDraftIdImport.update({
@@ -97,6 +109,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LeaguesLeagueIdScoresLazyImport
       parentRoute: typeof LeaguesLeagueIdImport
     }
+    '/leagues/$leagueId/rosters': {
+      id: '/leagues/$leagueId/rosters'
+      path: '/rosters'
+      fullPath: '/leagues/$leagueId/rosters'
+      preLoaderRoute: typeof LeaguesLeagueIdRostersLazyImport
+      parentRoute: typeof LeaguesLeagueIdImport
+    }
   }
 }
 
@@ -105,11 +124,13 @@ declare module '@tanstack/react-router' {
 interface LeaguesLeagueIdRouteChildren {
   LeaguesLeagueIdRankingsLazyRoute: typeof LeaguesLeagueIdRankingsLazyRoute
   LeaguesLeagueIdScoresLazyRoute: typeof LeaguesLeagueIdScoresLazyRoute
+  LeaguesLeagueIdRostersLazyRoute: typeof LeaguesLeagueIdRostersLazyRoute
 }
 
 const LeaguesLeagueIdRouteChildren: LeaguesLeagueIdRouteChildren = {
   LeaguesLeagueIdRankingsLazyRoute: LeaguesLeagueIdRankingsLazyRoute,
   LeaguesLeagueIdScoresLazyRoute: LeaguesLeagueIdScoresLazyRoute,
+  LeaguesLeagueIdRostersLazyRoute: LeaguesLeagueIdRostersLazyRoute,
 }
 
 const LeaguesLeagueIdRouteWithChildren = LeaguesLeagueIdRoute._addFileChildren(
@@ -122,6 +143,7 @@ export interface FileRoutesByFullPath {
   '/drafts/$draftId': typeof DraftsDraftIdRoute
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
+  '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
 }
 
 export interface FileRoutesByTo {
@@ -130,6 +152,7 @@ export interface FileRoutesByTo {
   '/drafts/$draftId': typeof DraftsDraftIdRoute
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
+  '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
 }
 
 export interface FileRoutesById {
@@ -139,6 +162,7 @@ export interface FileRoutesById {
   '/drafts//$draftId': typeof DraftsDraftIdRoute
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
+  '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
 }
 
 export interface FileRouteTypes {
@@ -149,6 +173,7 @@ export interface FileRouteTypes {
     | '/drafts/$draftId'
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
+    | '/leagues/$leagueId/rosters'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -156,6 +181,7 @@ export interface FileRouteTypes {
     | '/drafts/$draftId'
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
+    | '/leagues/$leagueId/rosters'
   id:
     | '__root__'
     | '/'
@@ -163,6 +189,7 @@ export interface FileRouteTypes {
     | '/drafts//$draftId'
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
+    | '/leagues/$leagueId/rosters'
   fileRoutesById: FileRoutesById
 }
 
@@ -202,7 +229,8 @@ export const routeTree = rootRoute
       "filePath": "leagues/$leagueId.tsx",
       "children": [
         "/leagues/$leagueId/rankings",
-        "/leagues/$leagueId/scores"
+        "/leagues/$leagueId/scores",
+        "/leagues/$leagueId/rosters"
       ]
     },
     "/drafts//$draftId": {
@@ -214,6 +242,10 @@ export const routeTree = rootRoute
     },
     "/leagues/$leagueId/scores": {
       "filePath": "leagues/$leagueId/scores.lazy.tsx",
+      "parent": "/leagues/$leagueId"
+    },
+    "/leagues/$leagueId/rosters": {
+      "filePath": "leagues/$leagueId/rosters.lazy.tsx",
       "parent": "/leagues/$leagueId"
     }
   }

--- a/frontend/src/routes/leagues/$leagueId/rosters.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/rosters.lazy.tsx
@@ -1,0 +1,11 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import RosterWeeks from "@/components/RosterWeeks";
+
+export const RostersPage = () => {
+  const { leagueId } = Route.useParams();
+  return <RosterWeeks leagueId={leagueId} />;
+};
+
+export const Route = createLazyFileRoute("/leagues/$leagueId/rosters")({
+  component: RostersPage,
+});

--- a/frontend/src/types/FantasyTeamRoster.ts
+++ b/frontend/src/types/FantasyTeamRoster.ts
@@ -1,0 +1,5 @@
+export type FantasyTeamRoster = {
+  fantasy_team_id: number;
+  fantasy_team_name: string;
+  roster: string[];
+};


### PR DESCRIPTION
## Summary
- add hook for league rosters
- show rosters using draft card styling with team icons
- expose rosters page as lazy route
- update route tree

## Testing
- `npm --prefix frontend run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686e83ce0e8083268030e2bb878b12d3