### PR TITLE
Improve draft order fetch handling

### DIFF
--- a/frontend/src/api/useDraftOrder.ts
+++ b/frontend/src/api/useDraftOrder.ts
@@ -3,7 +3,13 @@ import { DraftOrderPlayer } from "../types/DraftSlot"
 
 export const useDraftOrder = (draftId: string) => {
     return useQuery<DraftOrderPlayer[]>({
-        queryFn: () => fetch(`/api/drafts/${draftId}/draftOrder`).then((res) => res.json()),
+        queryFn: async () => {
+            const res = await fetch(`/api/drafts/${draftId}/draftOrder`)
+            if (!res.ok) {
+                throw new Error('Failed to fetch draft order')
+            }
+            return res.json() as Promise<DraftOrderPlayer[]>
+        },
         queryKey: ['draftOrder', draftId],
-    })
-}
+        enabled: !!draftId,
+    })}

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -32,16 +32,16 @@ const DraftBoard = () => {
 
   const draftOrderPlayers = useMemo(
     () =>
-      draftOrder.data?.map((order) => ({
-        ...order,
-        team: fantasyTeams.data?.find(
-          (team) => team.fantasy_team_id === order.fantasy_team_id,
-        ),
-      })),
+      Array.isArray(draftOrder.data)
+        ? draftOrder.data.map((order) => ({
+            ...order,
+            team: fantasyTeams.data?.find(
+              (t) => t.fantasy_team_id === order.fantasy_team_id,
+            ),
+          }))
+        : [],
     [draftOrder.data, fantasyTeams.data],
   )
-
-  console.log(draftOrder.data, fantasyTeams.data, draftOrderPlayers)
 
   if (!draft.data || !league.data || !picks.data || !draftOrder.data) {
     return <div>Loading...</div>


### PR DESCRIPTION
## Summary
- handle network errors in `useDraftOrder`
- check for draft ID before querying
- build `draftOrderPlayers` safely
- remove debug logging from draft board

## Testing
- `pnpm lint` *(fails: Parsing error in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_686e881054208326a1de4773cec06571