### PR TITLE
Add available teams page for leagues

### DIFF
--- a/frontend/src/api/useLeagueAvailableTeams.ts
+++ b/frontend/src/api/useLeagueAvailableTeams.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { AvailableTeam } from "@/types/AvailableTeam";
+
+export const useLeagueAvailableTeams = (leagueId: string | undefined) =>
+  useQuery<AvailableTeam[]>({
+    queryFn: () =>
+      fetch(`/api/leagues/${leagueId}/availableTeams`).then((res) => res.json()),
+    queryKey: ["leagueAvailableTeams", leagueId],
+    enabled: !!leagueId,
+  });

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as rootRoute } from './routes/__root'
 import { Route as LeaguesLeagueIdImport } from './routes/leagues/$leagueId'
 import { Route as DraftsDraftIdImport } from './routes/drafts/_.$draftId'
 import { Route as LeaguesLeagueIdRostersLazyImport } from './routes/leagues/$leagueId/rosters.lazy'
+import { Route as LeaguesLeagueIdAvailableLazyImport } from './routes/leagues/$leagueId/available.lazy'
 import { Route as DraftsDraftIdScoresLazyImport } from './routes/drafts/$draftId/scores.lazy'
 
 // Create Virtual Routes
@@ -31,6 +32,9 @@ const EventDataLazyImport = createFileRoute('/eventData')()
 
 const LeaguesLeagueIdRostersLazyImport = createFileRoute(
   '/leagues/$leagueId/rosters',
+)()
+const LeaguesLeagueIdAvailableLazyImport = createFileRoute(
+  '/leagues/$leagueId/available',
 )()
 const DraftsDraftIdScoresLazyImport = createFileRoute(
   '/drafts/$draftId/scores',
@@ -69,6 +73,14 @@ const LeaguesLeagueIdRostersLazyRoute =
     getParentRoute: () => LeaguesLeagueIdRoute,
   } as any).lazy(() =>
     import('./routes/leagues/$leagueId/rosters.lazy').then((d) => d.Route),
+  )
+
+const LeaguesLeagueIdAvailableLazyRoute =
+  LeaguesLeagueIdAvailableLazyImport.update({
+    path: '/available',
+    getParentRoute: () => LeaguesLeagueIdRoute,
+  } as any).lazy(() =>
+    import('./routes/leagues/$leagueId/available.lazy').then((d) => d.Route),
   )
 
 const DraftsDraftIdRoute = DraftsDraftIdImport.update({
@@ -143,6 +155,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LeaguesLeagueIdRostersLazyImport
       parentRoute: typeof LeaguesLeagueIdImport
     }
+    '/leagues/$leagueId/available': {
+      id: '/leagues/$leagueId/available'
+      path: '/available'
+      fullPath: '/leagues/$leagueId/available'
+      preLoaderRoute: typeof LeaguesLeagueIdAvailableLazyImport
+      parentRoute: typeof LeaguesLeagueIdImport
+    }
   }
 }
 
@@ -152,12 +171,14 @@ interface LeaguesLeagueIdRouteChildren {
   LeaguesLeagueIdRankingsLazyRoute: typeof LeaguesLeagueIdRankingsLazyRoute
   LeaguesLeagueIdScoresLazyRoute: typeof LeaguesLeagueIdScoresLazyRoute
   LeaguesLeagueIdRostersLazyRoute: typeof LeaguesLeagueIdRostersLazyRoute
+  LeaguesLeagueIdAvailableLazyRoute: typeof LeaguesLeagueIdAvailableLazyRoute
 }
 
 const LeaguesLeagueIdRouteChildren: LeaguesLeagueIdRouteChildren = {
   LeaguesLeagueIdRankingsLazyRoute: LeaguesLeagueIdRankingsLazyRoute,
   LeaguesLeagueIdScoresLazyRoute: LeaguesLeagueIdScoresLazyRoute,
   LeaguesLeagueIdRostersLazyRoute: LeaguesLeagueIdRostersLazyRoute,
+  LeaguesLeagueIdAvailableLazyRoute: LeaguesLeagueIdAvailableLazyRoute,
 }
 
 const LeaguesLeagueIdRouteWithChildren = LeaguesLeagueIdRoute._addFileChildren(
@@ -184,6 +205,7 @@ export interface FileRoutesByFullPath {
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
   '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
+  '/leagues/$leagueId/available': typeof LeaguesLeagueIdAvailableLazyRoute
 }
 
 export interface FileRoutesByTo {
@@ -194,6 +216,7 @@ export interface FileRoutesByTo {
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
   '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
+  '/leagues/$leagueId/available': typeof LeaguesLeagueIdAvailableLazyRoute
 }
 
 export interface FileRoutesById {
@@ -206,6 +229,7 @@ export interface FileRoutesById {
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
   '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
+  '/leagues/$leagueId/available': typeof LeaguesLeagueIdAvailableLazyRoute
 }
 
 export interface FileRouteTypes {
@@ -219,6 +243,7 @@ export interface FileRouteTypes {
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
     | '/leagues/$leagueId/rosters'
+    | '/leagues/$leagueId/available'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -229,6 +254,7 @@ export interface FileRouteTypes {
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
     | '/leagues/$leagueId/rosters'
+    | '/leagues/$leagueId/available'
   id:
     | '__root__'
     | '/'
@@ -239,6 +265,7 @@ export interface FileRouteTypes {
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
     | '/leagues/$leagueId/rosters'
+    | '/leagues/$leagueId/available'
   fileRoutesById: FileRoutesById
 }
 
@@ -283,7 +310,8 @@ export const routeTree = rootRoute
       "children": [
         "/leagues/$leagueId/rankings",
         "/leagues/$leagueId/scores",
-        "/leagues/$leagueId/rosters"
+        "/leagues/$leagueId/rosters",
+        "/leagues/$leagueId/available"
       ]
     },
     "/drafts//$draftId": {
@@ -305,6 +333,10 @@ export const routeTree = rootRoute
     },
     "/leagues/$leagueId/rosters": {
       "filePath": "leagues/$leagueId/rosters.lazy.tsx",
+      "parent": "/leagues/$leagueId"
+    },
+    "/leagues/$leagueId/available": {
+      "filePath": "leagues/$leagueId/available.lazy.tsx",
       "parent": "/leagues/$leagueId"
     },
     "/drafts/$draftId/scores": {

--- a/frontend/src/routes/leagues/$leagueId/available.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/available.lazy.tsx
@@ -1,0 +1,93 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { useLeague } from "@/api/useLeague";
+import { useLeagueAvailableTeams } from "@/api/useLeagueAvailableTeams";
+import React from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../../../components/ui/table";
+
+export const AvailableTeamsPage = () => {
+  const { leagueId } = Route.useParams();
+  const league = useLeague(leagueId);
+  const availableTeams = useLeagueAvailableTeams(leagueId);
+  const [selectedWeeks, setSelectedWeeks] = React.useState<number[]>([1, 2, 3, 4, 5]);
+
+  const toggleWeekSelection = (week: number) =>
+    setSelectedWeeks((prev) =>
+      prev.includes(week) ? prev.filter((w) => w !== week) : [...prev, week],
+    );
+
+  if (league.isLoading || availableTeams.isLoading) return <div>Loading...</div>;
+
+  const weeks = [1, 2, 3, 4, 5];
+  const teamEventsByWeek =
+    availableTeams.data?.map((team) => {
+      const events = weeks.map((w) => {
+        const ev = team.events.find((e) => e.week === w);
+        return ev ? ev.event_key : "";
+      });
+      return {
+        teamNumber: team.team_number,
+        teamName: team.name,
+        events,
+        yearEndEpa: team.year_end_epa,
+      };
+    }) ?? [];
+
+  const filteredTeams = league.data?.is_fim
+    ? teamEventsByWeek.filter(({ events }) =>
+        selectedWeeks.some((week) => events[week - 1] !== ""),
+      )
+    : teamEventsByWeek;
+
+  const prevYear = (league.data?.year ?? 0) - 1;
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead rowSpan={2}>Team #</TableHead>
+          <TableHead rowSpan={2}>Team Name</TableHead>
+          {league.data?.is_fim && <TableHead colSpan={5}>Week</TableHead>}
+          <TableHead rowSpan={2}>{league.data?.is_fim ? prevYear : league.data?.year} EPA</TableHead>
+        </TableRow>
+        {league.data?.is_fim && (
+          <TableRow>
+            {weeks.map((week) => (
+              <TableHead key={week} className="text-center">
+                <label className="flex items-center justify-between gap-2">
+                  <span>{week}</span>
+                  <input
+                    type="checkbox"
+                    checked={selectedWeeks.includes(week)}
+                    onChange={() => toggleWeekSelection(week)}
+                  />
+                </label>
+              </TableHead>
+            ))}
+          </TableRow>
+        )}
+      </TableHeader>
+      <TableBody>
+        {filteredTeams.map(({ teamNumber, teamName, events, yearEndEpa }) => (
+          <TableRow key={teamNumber}>
+            <TableCell>{teamNumber}</TableCell>
+            <TableCell>{teamName}</TableCell>
+            {league.data?.is_fim &&
+              events.map((ev, idx) => <TableCell key={idx}>{ev}</TableCell>)}
+            <TableCell>{yearEndEpa}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export const Route = createLazyFileRoute("/leagues/$leagueId/available")({
+  component: AvailableTeamsPage,
+});


### PR DESCRIPTION
## Summary
- fetch league available teams via new hook
- add route component to display available teams for a league
- update route tree to include new route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e97b696f88326bbe475a8b07106b5