### PR TITLE
Link FIM leagues to draft

### DIFF
--- a/frontend/src/api/useLeagueDrafts.ts
+++ b/frontend/src/api/useLeagueDrafts.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { Draft } from "@/types/Draft";
+
+export const useLeagueDrafts = (leagueId: string | undefined) =>
+  useQuery<Draft[]>({
+    queryFn: () =>
+      fetch(`/api/leagues/${leagueId}/drafts`).then((res) => res.json()),
+    queryKey: ["leagueDrafts", leagueId],
+    enabled: !!leagueId,
+  });

--- a/frontend/src/routes/leagues/$leagueId.tsx
+++ b/frontend/src/routes/leagues/$leagueId.tsx
@@ -6,21 +6,26 @@ import {
   useLocation,
 } from "@tanstack/react-router";
 import { useLeague } from "@/api/useLeague";
+import { useLeagueDrafts } from "@/api/useLeagueDrafts";
 import { Button } from "@/components/ui/button";
-
-const buttons = [
-  { label: "Rankings", to: "/leagues/$leagueId/rankings" },
-  { label: "Scores/Lineups", to: "/leagues/$leagueId/scores" },
-  { label: "Rosters", to: "/leagues/$leagueId/rosters" },
-  { label: "Available Teams", to: "/leagues/$leagueId/available" },
-  { label: "Waivers", to: "/leagues/$leagueId/waivers" },
-  { label: "Drafts", to: "/leagues/$leagueId/drafts" },
-];
 
 export const LeaguePage = () => {
   const { leagueId } = Route.useParams();
   const leagueData = useLeague(leagueId);
+  const drafts = useLeagueDrafts(leagueId);
   const location = useLocation();
+
+  const firstDraftId = drafts.data?.[0]?.draft_id;
+  const buttons = [
+    { label: "Rankings", to: "/leagues/$leagueId/rankings" },
+    { label: "Scores/Lineups", to: "/leagues/$leagueId/scores" },
+    { label: "Rosters", to: "/leagues/$leagueId/rosters" },
+    { label: "Available Teams", to: "/leagues/$leagueId/available" },
+    { label: "Waivers", to: "/leagues/$leagueId/waivers" },
+    leagueData.data?.is_fim && firstDraftId
+      ? { label: "Draft", to: `/drafts/${firstDraftId}` }
+      : { label: "Drafts", to: "/leagues/$leagueId/drafts" },
+  ];
 
   return (
     <div className="max-w-4xl mx-auto">


### PR DESCRIPTION
## Summary
- add `useLeagueDrafts` hook
- show a single Draft button for FIM leagues pointing to the first draft

## Testing
- `npm run lint`
- `python -m py_compile app.py models/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686e98cb9bfc8326ad845e691a0ad677