### PR TITLE
Implement waivers tab

### DIFF
--- a/frontend/src/api/useWaiverPriority.ts
+++ b/frontend/src/api/useWaiverPriority.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { WaiverPriority } from "@/types/WaiverPriority";
+
+export const useWaiverPriority = (leagueId: string | undefined) =>
+  useQuery<WaiverPriority[]>({
+    queryFn: () =>
+      fetch(`/api/leagues/${leagueId}/waiverPriority`).then((res) => res.json()),
+    queryKey: ["waiverPriority", leagueId],
+    enabled: !!leagueId,
+  });

--- a/frontend/src/api/useWaiverTeams.ts
+++ b/frontend/src/api/useWaiverTeams.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { WaiverTeam } from "@/types/WaiverTeam";
+
+export const useWaiverTeams = (leagueId: string | undefined) =>
+  useQuery<WaiverTeam[]>({
+    queryFn: () =>
+      fetch(`/api/leagues/${leagueId}/teamsOnWaivers`).then((res) => res.json()),
+    queryKey: ["waiverTeams", leagueId],
+    enabled: !!leagueId,
+  });

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as rootRoute } from './routes/__root'
 import { Route as LeaguesLeagueIdImport } from './routes/leagues/$leagueId'
 import { Route as DraftsDraftIdImport } from './routes/drafts/_.$draftId'
 import { Route as LeaguesLeagueIdRostersLazyImport } from './routes/leagues/$leagueId/rosters.lazy'
+import { Route as LeaguesLeagueIdWaiversLazyImport } from './routes/leagues/$leagueId/waivers.lazy'
 import { Route as DraftsDraftIdScoresLazyImport } from './routes/drafts/$draftId/scores.lazy'
 
 // Create Virtual Routes
@@ -31,6 +32,9 @@ const EventDataLazyImport = createFileRoute('/eventData')()
 
 const LeaguesLeagueIdRostersLazyImport = createFileRoute(
   '/leagues/$leagueId/rosters',
+)()
+const LeaguesLeagueIdWaiversLazyImport = createFileRoute(
+  '/leagues/$leagueId/waivers',
 )()
 const DraftsDraftIdScoresLazyImport = createFileRoute(
   '/drafts/$draftId/scores',
@@ -69,6 +73,14 @@ const LeaguesLeagueIdRostersLazyRoute =
     getParentRoute: () => LeaguesLeagueIdRoute,
   } as any).lazy(() =>
     import('./routes/leagues/$leagueId/rosters.lazy').then((d) => d.Route),
+  )
+
+const LeaguesLeagueIdWaiversLazyRoute =
+  LeaguesLeagueIdWaiversLazyImport.update({
+    path: '/waivers',
+    getParentRoute: () => LeaguesLeagueIdRoute,
+  } as any).lazy(() =>
+    import('./routes/leagues/$leagueId/waivers.lazy').then((d) => d.Route),
   )
 
 const DraftsDraftIdRoute = DraftsDraftIdImport.update({
@@ -143,6 +155,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LeaguesLeagueIdRostersLazyImport
       parentRoute: typeof LeaguesLeagueIdImport
     }
+    '/leagues/$leagueId/waivers': {
+      id: '/leagues/$leagueId/waivers'
+      path: '/waivers'
+      fullPath: '/leagues/$leagueId/waivers'
+      preLoaderRoute: typeof LeaguesLeagueIdWaiversLazyImport
+      parentRoute: typeof LeaguesLeagueIdImport
+    }
   }
 }
 
@@ -152,12 +171,14 @@ interface LeaguesLeagueIdRouteChildren {
   LeaguesLeagueIdRankingsLazyRoute: typeof LeaguesLeagueIdRankingsLazyRoute
   LeaguesLeagueIdScoresLazyRoute: typeof LeaguesLeagueIdScoresLazyRoute
   LeaguesLeagueIdRostersLazyRoute: typeof LeaguesLeagueIdRostersLazyRoute
+  LeaguesLeagueIdWaiversLazyRoute: typeof LeaguesLeagueIdWaiversLazyRoute
 }
 
 const LeaguesLeagueIdRouteChildren: LeaguesLeagueIdRouteChildren = {
   LeaguesLeagueIdRankingsLazyRoute: LeaguesLeagueIdRankingsLazyRoute,
   LeaguesLeagueIdScoresLazyRoute: LeaguesLeagueIdScoresLazyRoute,
   LeaguesLeagueIdRostersLazyRoute: LeaguesLeagueIdRostersLazyRoute,
+  LeaguesLeagueIdWaiversLazyRoute: LeaguesLeagueIdWaiversLazyRoute,
 }
 
 const LeaguesLeagueIdRouteWithChildren = LeaguesLeagueIdRoute._addFileChildren(
@@ -184,6 +205,7 @@ export interface FileRoutesByFullPath {
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
   '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
+  '/leagues/$leagueId/waivers': typeof LeaguesLeagueIdWaiversLazyRoute
 }
 
 export interface FileRoutesByTo {
@@ -194,6 +216,7 @@ export interface FileRoutesByTo {
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
   '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
+  '/leagues/$leagueId/waivers': typeof LeaguesLeagueIdWaiversLazyRoute
 }
 
 export interface FileRoutesById {
@@ -206,6 +229,7 @@ export interface FileRoutesById {
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
   '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
+  '/leagues/$leagueId/waivers': typeof LeaguesLeagueIdWaiversLazyRoute
 }
 
 export interface FileRouteTypes {
@@ -219,6 +243,7 @@ export interface FileRouteTypes {
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
     | '/leagues/$leagueId/rosters'
+    | '/leagues/$leagueId/waivers'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -229,6 +254,7 @@ export interface FileRouteTypes {
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
     | '/leagues/$leagueId/rosters'
+    | '/leagues/$leagueId/waivers'
   id:
     | '__root__'
     | '/'
@@ -239,6 +265,7 @@ export interface FileRouteTypes {
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
     | '/leagues/$leagueId/rosters'
+    | '/leagues/$leagueId/waivers'
   fileRoutesById: FileRoutesById
 }
 
@@ -283,7 +310,8 @@ export const routeTree = rootRoute
       "children": [
         "/leagues/$leagueId/rankings",
         "/leagues/$leagueId/scores",
-        "/leagues/$leagueId/rosters"
+        "/leagues/$leagueId/rosters",
+        "/leagues/$leagueId/waivers"
       ]
     },
     "/drafts//$draftId": {
@@ -305,6 +333,10 @@ export const routeTree = rootRoute
     },
     "/leagues/$leagueId/rosters": {
       "filePath": "leagues/$leagueId/rosters.lazy.tsx",
+      "parent": "/leagues/$leagueId"
+    },
+    "/leagues/$leagueId/waivers": {
+      "filePath": "leagues/$leagueId/waivers.lazy.tsx",
       "parent": "/leagues/$leagueId"
     },
     "/drafts/$draftId/scores": {

--- a/frontend/src/routes/leagues/$leagueId/waivers.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/waivers.lazy.tsx
@@ -1,0 +1,160 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { useLeague } from "@/api/useLeague";
+import { useWaiverTeams } from "@/api/useWaiverTeams";
+import { useWaiverPriority } from "@/api/useWaiverPriority";
+import { WaiverPriority } from "@/types/WaiverPriority";
+import React, { useState } from "react";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+
+export const WaiversPage = () => {
+  const { leagueId } = Route.useParams();
+  const league = useLeague(leagueId);
+  const waiverTeams = useWaiverTeams(leagueId);
+  const waiverPriority = useWaiverPriority(leagueId);
+
+  const [activeTab, setActiveTab] = useState<'teams' | 'priority'>('teams');
+  const [selectedWeeks, setSelectedWeeks] = useState<number[]>([1, 2, 3, 4, 5]);
+
+  const toggleWeekSelection = (week: number) => {
+    setSelectedWeeks((prev) =>
+      prev.includes(week) ? prev.filter((w) => w !== week) : [...prev, week]
+    );
+  };
+
+  if (
+    league.isLoading ||
+    waiverTeams.isLoading ||
+    waiverPriority.isLoading
+  ) {
+    return <div>Loading...</div>;
+  }
+
+  const renderWaiverTeams = () => {
+    if (!league.data || !waiverTeams.data) return null;
+
+    const weeks = [1, 2, 3, 4, 5];
+    const teams = waiverTeams.data.map((team): {
+      teamNumber: number;
+      teamName: string;
+      events: string[];
+      yearEndEpa?: number;
+    } => {
+      const events = weeks.map((w) => {
+        const ev = team.events.find((e) => e.week === w);
+        return ev ? ev.event_key : "";
+      });
+      return {
+        teamNumber: team.team_number,
+        teamName: team.name,
+        events,
+        yearEndEpa: team.year_end_epa,
+      };
+    });
+
+    const filtered = league.data.is_fim
+      ? teams.filter(({ events }) =>
+          selectedWeeks.some((w) => events[w - 1] !== "")
+        )
+      : teams;
+
+    const prevYear = league.data.year - 1;
+
+    return (
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead rowSpan={league.data.is_fim ? 2 : 1}>Team #</TableHead>
+            <TableHead rowSpan={league.data.is_fim ? 2 : 1}>Team Name</TableHead>
+            {league.data.is_fim && <TableHead colSpan={5}>Week</TableHead>}
+            <TableHead rowSpan={league.data.is_fim ? 2 : 1}>
+              {league.data.is_fim ? prevYear : league.data.year} EPA
+            </TableHead>
+          </TableRow>
+          {league.data.is_fim && (
+            <TableRow>
+              {weeks.map((week) => (
+                <TableHead key={week}>
+                  <label className="flex items-center gap-2">
+                    <span>{week}</span>
+                    <input
+                      type="checkbox"
+                      checked={selectedWeeks.includes(week)}
+                      onChange={() => toggleWeekSelection(week)}
+                    />
+                  </label>
+                </TableHead>
+              ))}
+            </TableRow>
+          )}
+        </TableHeader>
+        <TableBody>
+          {filtered.map((team) => (
+            <TableRow key={team.teamNumber}>
+              <TableCell>{team.teamNumber}</TableCell>
+              <TableCell>{team.teamName}</TableCell>
+              {league.data.is_fim &&
+                team.events.map((ev: string, i: number) => (
+                  <TableCell key={i}>{ev}</TableCell>
+                ))}
+              <TableCell>{team.yearEndEpa ?? ''}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  };
+
+  const renderWaiverPriority = () => {
+    if (!waiverPriority.data) return null;
+    return (
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Priority</TableHead>
+            <TableHead>Fantasy Team</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {waiverPriority.data.map((w: WaiverPriority) => (
+            <TableRow key={w.fantasy_team_id}>
+              <TableCell>{w.priority}</TableCell>
+              <TableCell>{w.fantasy_team_name}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <Button
+          variant={activeTab === 'teams' ? 'default' : 'outline'}
+          onClick={() => setActiveTab('teams')}
+        >
+          Teams on Waivers
+        </Button>
+        <Button
+          variant={activeTab === 'priority' ? 'default' : 'outline'}
+          onClick={() => setActiveTab('priority')}
+        >
+          Waiver Priority
+        </Button>
+      </div>
+      {activeTab === 'teams' ? renderWaiverTeams() : renderWaiverPriority()}
+    </div>
+  );
+};
+
+export const Route = createLazyFileRoute('/leagues/$leagueId/waivers')({
+  component: WaiversPage,
+});

--- a/frontend/src/types/WaiverPriority.ts
+++ b/frontend/src/types/WaiverPriority.ts
@@ -1,0 +1,5 @@
+export type WaiverPriority = {
+  fantasy_team_id: number;
+  fantasy_team_name: string;
+  priority: number;
+};

--- a/frontend/src/types/WaiverTeam.ts
+++ b/frontend/src/types/WaiverTeam.ts
@@ -1,0 +1,9 @@
+export type WaiverTeam = {
+  team_number: number;
+  name: string;
+  events: {
+    event_key: string;
+    week: number;
+  }[];
+  year_end_epa?: number;
+};


### PR DESCRIPTION
## Summary
- add hooks to fetch waiver data
- implement Waivers tab page with week filters
- register new route in route tree
- define data models for waivers

## Testing
- `npm run build` *(fails: Cannot find module 'path' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686e986f4dd083269bfcc9a04cddb94e