### PR TITLE
Add leagues and offseason drafts pages

### DIFF
--- a/frontend/src/api/useLeagueDrafts.ts
+++ b/frontend/src/api/useLeagueDrafts.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { Draft } from "@/types/Draft";
+
+export const useLeagueDrafts = (leagueId: string | undefined) =>
+  useQuery<Draft[]>({
+    queryFn: () =>
+      fetch(`/api/leagues/${leagueId}/drafts`).then((res) => res.json()),
+    queryKey: ["leagueDrafts", leagueId],
+    enabled: !!leagueId,
+  });

--- a/frontend/src/api/useLeagues.ts
+++ b/frontend/src/api/useLeagues.ts
@@ -1,0 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
+import { League } from "@/types/League";
+
+export const useLeagues = () =>
+  useQuery<League[]>({
+    queryFn: () => fetch("/api/leagues").then((res) => res.json()),
+    queryKey: ["leagues"],
+  });

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -15,6 +15,16 @@ export const Navbar = () => {
           </Link>
         </li>
         <li>
+          <Link to="/leagues" className="hover:underline">
+            Leagues
+          </Link>
+        </li>
+        <li>
+          <Link to="/offseasonDrafts" className="hover:underline">
+            Offseason Drafts
+          </Link>
+        </li>
+        <li>
           <a href="/apidocs" className="hover:underline">
             API
           </a>
@@ -33,5 +43,4 @@ export const Navbar = () => {
     </nav>
   );
 };
-
 export default Navbar;

--- a/frontend/src/routes/leagues/index.lazy.tsx
+++ b/frontend/src/routes/leagues/index.lazy.tsx
@@ -1,0 +1,35 @@
+import { createLazyFileRoute, Link } from "@tanstack/react-router";
+import { useLeagues } from "@/api/useLeagues";
+
+export const LeaguesPage = () => {
+  const leagues = useLeagues();
+
+  if (leagues.isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  const fimLeagues = leagues.data?.filter((l) => l.is_fim) ?? [];
+
+  return (
+    <div className="space-y-2">
+      <h1 className="text-3xl font-bold mb-4">Leagues</h1>
+      <ul className="list-disc ml-4">
+        {fimLeagues.map((league) => (
+          <li key={league.league_id}>
+            <Link
+              to="/leagues/$leagueId"
+              params={{ leagueId: league.league_id.toString() }}
+              className="hover:underline"
+            >
+              {league.league_name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export const Route = createLazyFileRoute("/leagues")({
+  component: LeaguesPage,
+});

--- a/frontend/src/routes/offseasonDrafts.lazy.tsx
+++ b/frontend/src/routes/offseasonDrafts.lazy.tsx
@@ -1,0 +1,56 @@
+import { createLazyFileRoute, Link } from "@tanstack/react-router";
+import { useLeagues } from "@/api/useLeagues";
+import { useLeagueDrafts } from "@/api/useLeagueDrafts";
+import { League } from "@/types/League";
+
+const OffseasonLeague = ({ league }: { league: League }) => {
+  const drafts = useLeagueDrafts(league.league_id.toString());
+
+  if (drafts.isLoading) {
+    return <div>Loading drafts...</div>;
+  }
+
+  if (!drafts.data?.length) return null;
+
+  return (
+    <div className="mb-4">
+      <h2 className="text-2xl font-semibold">{league.league_name}</h2>
+      <ul className="list-disc ml-4">
+        {drafts.data.map((draft) => (
+          <li key={draft.draft_id}>
+            <Link
+              to="/drafts/$draftId"
+              params={{ draftId: draft.draft_id.toString() }}
+              className="hover:underline"
+            >
+              {draft.event_key}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export const OffseasonDraftsPage = () => {
+  const leagues = useLeagues();
+
+  if (leagues.isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  const offseasonLeagues = leagues.data?.filter((l) => l.offseason) ?? [];
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold mb-4">Offseason Drafts</h1>
+      {offseasonLeagues.map((league) => (
+        <OffseasonLeague key={league.league_id} league={league} />
+      ))}
+    </div>
+  );
+};
+
+export const Route = createLazyFileRoute("/offseasonDrafts")({
+  component: OffseasonDraftsPage,
+});

--- a/frontend/src/types/League.ts
+++ b/frontend/src/types/League.ts
@@ -1,7 +1,10 @@
-export type League = {
-    is_fim: boolean;
-    league_id: number;
-    league_name: string;
-    weekly_starts: number;
-    year: number;
-}
+export type League = {  league_id: number;
+  league_name: string;
+  year: number;
+  is_fim: boolean;
+  offseason: boolean;
+  team_limit: number;
+  team_starts: number;
+  team_size_limit: number;
+  weekly_starts?: number;
+};


### PR DESCRIPTION
## Summary
- add hooks for leagues and league drafts
- create Leagues page listing FiM leagues
- create Offseason Drafts page listing drafts for offseason leagues
- link new pages from Navbar
- extend League type with additional fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS errors due to missing type definitions and route generation)*

------
https://chatgpt.com/codex/tasks/task_e_686e99605ae48326948e7f16b593df4f