### PR TITLE
Add offseason draft scores link

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,13 +167,23 @@ def get_league(leagueId):
               is_fim:
                 type: bool
                 example: True
+              offseason:
+                type: bool
+                example: False
       500:
         description: Internal server error.
     """
     session = Session()
     league = session.query(League).filter(League.active==True, League.league_id==leagueId).first()
     session.close()
-    return jsonify({"league_id": league.league_id, "league_name": league.league_name, "weekly_starts": league.team_starts, "year": league.year, "is_fim": league.is_fim} )
+    return jsonify({
+        "league_id": league.league_id,
+        "league_name": league.league_name,
+        "weekly_starts": league.team_starts,
+        "year": league.year,
+        "is_fim": league.is_fim,
+        "offseason": league.offseason,
+    })
 
 @app.route('/api/leagues/<int:leagueId>/fantasyTeams', methods=['GET'])
 def get_fantasy_teams(leagueId):

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { useDraft } from '@/api/useDraft'
 import { useLeague } from '@/api/useLeague'
 import { usePicks } from '@/api/usePicks'
@@ -8,6 +8,7 @@ import { useFantasyTeams } from '@/api/useFantasyTeams'
 import { useMemo, useState } from 'react'
 import { useTeamAvatar } from '@/api/useTeamAvatar'
 import { useAvailableTeams } from '@/api/useAvailableTeams'
+import { Button } from '@/components/ui/button'
 
 const DraftBoard = () => {
   const { draftId } = Route.useParams()
@@ -141,6 +142,13 @@ const DraftBoard = () => {
   return (
     <div className="w-full min-w-[1000px] overflow-x-scroll overflow-y-scroll">
       <h1 className="text-3xl font-bold text-center">{league.data?.league_name}</h1>
+      {league.data.offseason && (
+        <div className="text-center my-4">
+          <Link to="/drafts/$draftId/scores" params={{ draftId }}>
+            <Button>View Draft Scores</Button>
+          </Link>
+        </div>
+      )}
 
       <div
         className={`grid`}

--- a/frontend/src/types/League.ts
+++ b/frontend/src/types/League.ts
@@ -4,4 +4,4 @@ export type League = {
     league_name: string;
     weekly_starts: number;
     year: number;
-}
+    offseason?: boolean;}


### PR DESCRIPTION
## Summary
- include offseason field in league API response
- update League type to include offseason
- show "View Draft Scores" button for offseason drafts

## Testing
- `npm run lint`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_686e99dc751083268b7876054ae4b354