### PR TITLE
Add league link from in-season draft

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,13 +167,23 @@ def get_league(leagueId):
               is_fim:
                 type: bool
                 example: True
+              offseason:
+                type: bool
+                example: False
       500:
         description: Internal server error.
     """
     session = Session()
     league = session.query(League).filter(League.active==True, League.league_id==leagueId).first()
     session.close()
-    return jsonify({"league_id": league.league_id, "league_name": league.league_name, "weekly_starts": league.team_starts, "year": league.year, "is_fim": league.is_fim} )
+    return jsonify({
+        "league_id": league.league_id,
+        "league_name": league.league_name,
+        "weekly_starts": league.team_starts,
+        "year": league.year,
+        "is_fim": league.is_fim,
+        "offseason": league.offseason,
+    })
 
 @app.route('/api/leagues/<int:leagueId>/fantasyTeams', methods=['GET'])
 def get_fantasy_teams(leagueId):

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { useDraft } from '@/api/useDraft'
 import { useLeague } from '@/api/useLeague'
 import { usePicks } from '@/api/usePicks'
@@ -8,6 +8,7 @@ import { useFantasyTeams } from '@/api/useFantasyTeams'
 import { useMemo, useState } from 'react'
 import { useTeamAvatar } from '@/api/useTeamAvatar'
 import { useAvailableTeams } from '@/api/useAvailableTeams'
+import { Button } from '@/components/ui/button'
 
 const DraftBoard = () => {
   const { draftId } = Route.useParams()
@@ -140,7 +141,14 @@ const DraftBoard = () => {
 
   return (
     <div className="w-full min-w-[1000px] overflow-x-scroll overflow-y-scroll">
-      <h1 className="text-3xl font-bold text-center">{league.data?.league_name}</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold text-center flex-1">{league.data?.league_name}</h1>
+        {league.data && !league.data.offseason && (
+          <Link to="/leagues/$leagueId" params={{ leagueId: league.data.league_id.toString() }}>
+            <Button variant="outline">Back to League</Button>
+          </Link>
+        )}
+      </div>
 
       <div
         className={`grid`}

--- a/frontend/src/types/League.ts
+++ b/frontend/src/types/League.ts
@@ -3,5 +3,5 @@ export type League = {
     league_id: number;
     league_name: string;
     weekly_starts: number;
-    year: number;
-}
+    offseason: boolean;
+    year: number;}


### PR DESCRIPTION
## Summary
- include `offseason` flag in single league API
- update League type with offseason boolean
- add link back to league from draft board when not offseason
- ensure draft board only shows league link when league data is loaded

## Testing
- `npm run lint`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686e9ae3eabc8326acd33c5cdd1321cc