### PR TITLE
Add league weeks tab to FiM draft

### DIFF
--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as DraftsDraftIdImport } from './routes/drafts/_.$draftId'
 import { Route as LeaguesLeagueIdRostersLazyImport } from './routes/leagues/$leagueId/rosters.lazy'
 import { Route as LeaguesLeagueIdWaiversLazyImport } from './routes/leagues/$leagueId/waivers.lazy'
 import { Route as DraftsDraftIdScoresLazyImport } from './routes/drafts/$draftId/scores.lazy'
+import { Route as DraftsDraftIdLeagueWeeksLazyImport } from './routes/drafts/$draftId/leagueWeeks.lazy'
 
 // Create Virtual Routes
 
@@ -38,6 +39,9 @@ const LeaguesLeagueIdWaiversLazyImport = createFileRoute(
 )()
 const DraftsDraftIdScoresLazyImport = createFileRoute(
   '/drafts/$draftId/scores',
+)()
+const DraftsDraftIdLeagueWeeksLazyImport = createFileRoute(
+  '/drafts/$draftId/leagueWeeks',
 )()
 
 // Create/Update Routes
@@ -93,6 +97,13 @@ const DraftsDraftIdScoresLazyRoute = DraftsDraftIdScoresLazyImport.update({
   getParentRoute: () => DraftsDraftIdRoute,
 } as any).lazy(() =>
   import('./routes/drafts/$draftId/scores.lazy').then((d) => d.Route),
+)
+
+const DraftsDraftIdLeagueWeeksLazyRoute = DraftsDraftIdLeagueWeeksLazyImport.update({
+  path: '/leagueWeeks',
+  getParentRoute: () => DraftsDraftIdRoute,
+} as any).lazy(() =>
+  import('./routes/drafts/$draftId/leagueWeeks.lazy').then((d) => d.Route),
 )
 
 const EventDataLazyRoute = EventDataLazyImport.update({
@@ -162,6 +173,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LeaguesLeagueIdWaiversLazyImport
       parentRoute: typeof LeaguesLeagueIdImport
     }
+    '/drafts/$draftId/leagueWeeks': {
+      id: '/drafts/$draftId/leagueWeeks'
+      path: '/leagueWeeks'
+      fullPath: '/drafts/$draftId/leagueWeeks'
+      preLoaderRoute: typeof DraftsDraftIdLeagueWeeksLazyImport
+      parentRoute: typeof DraftsDraftIdImport
+    }
   }
 }
 
@@ -187,10 +205,12 @@ const LeaguesLeagueIdRouteWithChildren = LeaguesLeagueIdRoute._addFileChildren(
 
 interface DraftsDraftIdRouteChildren {
   DraftsDraftIdScoresLazyRoute: typeof DraftsDraftIdScoresLazyRoute
+  DraftsDraftIdLeagueWeeksLazyRoute: typeof DraftsDraftIdLeagueWeeksLazyRoute
 }
 
 const DraftsDraftIdRouteChildren: DraftsDraftIdRouteChildren = {
   DraftsDraftIdScoresLazyRoute: DraftsDraftIdScoresLazyRoute,
+  DraftsDraftIdLeagueWeeksLazyRoute: DraftsDraftIdLeagueWeeksLazyRoute,
 }
 
 const DraftsDraftIdRouteWithChildren = DraftsDraftIdRoute._addFileChildren(
@@ -206,6 +226,7 @@ export interface FileRoutesByFullPath {
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
   '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
   '/leagues/$leagueId/waivers': typeof LeaguesLeagueIdWaiversLazyRoute
+  '/drafts/$draftId/leagueWeeks': typeof DraftsDraftIdLeagueWeeksLazyRoute
 }
 
 export interface FileRoutesByTo {
@@ -217,6 +238,7 @@ export interface FileRoutesByTo {
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
   '/leagues/$leagueId/rosters': typeof LeaguesLeagueIdRostersLazyRoute
   '/leagues/$leagueId/waivers': typeof LeaguesLeagueIdWaiversLazyRoute
+  '/drafts/$draftId/leagueWeeks': typeof DraftsDraftIdLeagueWeeksLazyRoute
 }
 
 export interface FileRoutesById {
@@ -225,6 +247,7 @@ export interface FileRoutesById {
   '/leagues/$leagueId': typeof LeaguesLeagueIdRouteWithChildren
   '/drafts//$draftId': typeof DraftsDraftIdRouteWithChildren
   '/drafts/$draftId/scores': typeof DraftsDraftIdScoresLazyRoute
+  '/drafts/$draftId/leagueWeeks': typeof DraftsDraftIdLeagueWeeksLazyRoute
   '/eventData': typeof EventDataLazyRoute
   '/leagues/$leagueId/rankings': typeof LeaguesLeagueIdRankingsLazyRoute
   '/leagues/$leagueId/scores': typeof LeaguesLeagueIdScoresLazyRoute
@@ -239,6 +262,7 @@ export interface FileRouteTypes {
     | '/leagues/$leagueId'
     | '/drafts/$draftId'
     | '/drafts/$draftId/scores'
+    | '/drafts/$draftId/leagueWeeks'
     | '/eventData'
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
@@ -246,10 +270,11 @@ export interface FileRouteTypes {
     | '/leagues/$leagueId/waivers'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | '/'
+    | '/' 
     | '/leagues/$leagueId'
     | '/drafts/$draftId'
     | '/drafts/$draftId/scores'
+    | '/drafts/$draftId/leagueWeeks'
     | '/eventData'
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
@@ -257,10 +282,11 @@ export interface FileRouteTypes {
     | '/leagues/$leagueId/waivers'
   id:
     | '__root__'
-    | '/'
+    | '/' 
     | '/leagues/$leagueId'
     | '/drafts//$draftId'
     | '/drafts/$draftId/scores'
+    | '/drafts/$draftId/leagueWeeks'
     | '/eventData'
     | '/leagues/$leagueId/rankings'
     | '/leagues/$leagueId/scores'
@@ -299,6 +325,7 @@ export const routeTree = rootRoute
         "/leagues/$leagueId",
         "/drafts//$draftId",
         "/drafts/$draftId/scores",
+        "/drafts/$draftId/leagueWeeks",
         "/eventData"
       ]
     },
@@ -317,7 +344,8 @@ export const routeTree = rootRoute
     "/drafts//$draftId": {
       "filePath": "drafts/_.$draftId.tsx",
       "children": [
-        "/drafts/$draftId/scores"
+        "/drafts/$draftId/scores",
+        "/drafts/$draftId/leagueWeeks"
       ]
     },
     "/eventData": {
@@ -341,6 +369,10 @@ export const routeTree = rootRoute
     },
     "/drafts/$draftId/scores": {
       "filePath": "drafts/$draftId/scores.lazy.tsx",
+      "parent": "/drafts//$draftId"
+    },
+    "/drafts/$draftId/leagueWeeks": {
+      "filePath": "drafts/$draftId/leagueWeeks.lazy.tsx",
       "parent": "/drafts//$draftId"
     }
   }

--- a/frontend/src/routes/drafts/$draftId/leagueWeeks.lazy.tsx
+++ b/frontend/src/routes/drafts/$draftId/leagueWeeks.lazy.tsx
@@ -1,0 +1,85 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { useDraft } from "@/api/useDraft";
+import { useLeague } from "@/api/useLeague";
+import { useFantasyTeams } from "@/api/useFantasyTeams";
+import { usePicks } from "@/api/usePicks";
+import React from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export const DraftLeagueWeeksPage = () => {
+  const { draftId } = Route.useParams();
+  const draft = useDraft(draftId);
+  const league = useLeague(draft.data?.league_id.toString());
+  const draftPicks = usePicks(draftId);
+  const fantasyTeams = useFantasyTeams(league.data?.league_id.toString());
+
+  if (
+    draft.isLoading ||
+    league.isLoading ||
+    draftPicks.isLoading ||
+    fantasyTeams.isLoading
+  ) {
+    return <div>Loading...</div>;
+  }
+
+  const fantasyTeamWeekCounts: Record<number, number[]> = {};
+  fantasyTeams.data?.forEach((team) => {
+    fantasyTeamWeekCounts[team.fantasy_team_id] = [0, 0, 0, 0, 0];
+  });
+
+  draftPicks.data?.forEach((pick) => {
+    pick.events.forEach((event) => {
+      if (event.week >= 1 && event.week <= 5) {
+        fantasyTeamWeekCounts[pick.fantasy_team_id][event.week - 1] += 1;
+      }
+    });
+  });
+
+  const weeks = [1, 2, 3, 4, 5];
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Fantasy Team</TableHead>
+          {weeks.map((w) => (
+            <TableHead key={w}>Week {w}</TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {fantasyTeams.data?.map((team) => (
+          <TableRow key={team.fantasy_team_id}>
+            <TableCell className="font-bold">{team.team_name}</TableCell>
+            {fantasyTeamWeekCounts[team.fantasy_team_id].map((count, index) => {
+              let className = "";
+              if (league.data && count >= league.data.weekly_starts) {
+                className = "bg-green-300";
+              } else if (league.data && count === league.data.weekly_starts - 1) {
+                className = "bg-yellow-300";
+              } else {
+                className = "bg-red-300";
+              }
+              return (
+                <TableCell key={index} className={className}>
+                  {count}
+                </TableCell>
+              );
+            })}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export const Route = createLazyFileRoute("/drafts/$draftId/leagueWeeks")({
+  component: DraftLeagueWeeksPage,
+});

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useLocation } from '@tanstack/react-router'
 import { useDraft } from '@/api/useDraft'
 import { useLeague } from '@/api/useLeague'
 import { usePicks } from '@/api/usePicks'
@@ -139,14 +139,28 @@ const DraftBoard = () => {
     )
   }
 
+  const location = useLocation()
+
   return (
     <div className="w-full min-w-[1000px] overflow-x-scroll overflow-y-scroll">
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold text-center flex-1">{league.data?.league_name}</h1>
+      <div className="flex flex-col items-center">
+        <h1 className="text-3xl font-bold text-center">{league.data?.league_name}</h1>
         {league.data && !league.data.offseason && (
-          <Link to="/leagues/$leagueId" params={{ leagueId: league.data.league_id.toString() }}>
-            <Button variant="outline">Back to League</Button>
-          </Link>
+          <div className="flex gap-2 mt-2">
+            <Link to="/drafts/$draftId" params={{ draftId }}>
+              <Button variant={location.pathname.endsWith('/leagueWeeks') ? 'outline' : 'default'}>
+                Draft
+              </Button>
+            </Link>
+            <Link to="/drafts/$draftId/leagueWeeks" params={{ draftId }}>
+              <Button variant={location.pathname.endsWith('/leagueWeeks') ? 'default' : 'outline'}>
+                League Weeks
+              </Button>
+            </Link>
+            <Link to="/leagues/$leagueId" params={{ leagueId: league.data.league_id.toString() }}>
+              <Button variant="outline">Back to League</Button>
+            </Link>
+          </div>
         )}
       </div>
       {league.data.offseason && (


### PR DESCRIPTION
## Summary
- add `leagueWeeks` draft route
- refactor FiM draft page header into Draft/League Weeks/Back tabs
- show table of drafted teams per week with success/warning/error coloring
- register the new route in `routeTree.gen.ts`

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ea0459a8883268139c00dc345569e