### PR TITLE
Use Statbotics for EPA on draft page

### DIFF
--- a/frontend/src/api/useStatboticsTeamYear.ts
+++ b/frontend/src/api/useStatboticsTeamYear.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+
+export const useStatboticsTeamYear = (
+  team: number | string | undefined,
+  year: number | undefined,
+) => {
+  return useQuery<number | null>({
+    queryKey: ["statbotics-team-year", team, year],
+    enabled: !!team && !!year,
+    queryFn: async () => {
+      const response = await fetch(
+        `https://api.statbotics.io/v3/team_year/${team}/${year}`,
+      );
+      if (!response.ok) return null;
+      try {
+        const data = await response.json();
+        return typeof data?.epa?.unitless === "number" ? data.epa.unitless : null;
+      } catch {
+        return null;
+      }
+    },
+    staleTime: 1000 * 60 * 60 * 24,
+    cacheTime: 1000 * 60 * 60 * 24,
+  });
+};

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -8,6 +8,7 @@ import { useFantasyTeams } from '@/api/useFantasyTeams'
 import { useMemo, useState } from 'react'
 import { useTeamAvatar } from '@/api/useTeamAvatar'
 import { useAvailableTeams } from '@/api/useAvailableTeams'
+import { useStatboticsTeamYear } from "@/api/useStatboticsTeamYear"
 import { Button } from '@/components/ui/button'
 
 const DraftBoard = () => {
@@ -22,6 +23,7 @@ const DraftBoard = () => {
   const draftOrder = useDraftOrder(draftId)
   const fantasyTeams = useFantasyTeams(league.data?.league_id.toString())
   const availableTeams = useAvailableTeams(draftId)
+  const location = useLocation()
 
   const [selectedWeeks, setSelectedWeeks] = useState<number[]>([1, 2, 3, 4, 5])
 
@@ -73,7 +75,6 @@ const DraftBoard = () => {
         teamNumber: team.team_number,
         teamName: team.name,
         events,
-        yearEndEpa: team.year_end_epa,
       }
     })
 
@@ -87,6 +88,7 @@ const DraftBoard = () => {
     }
 
     const prevYear = league.data.year - 1
+    const epaYear = league.data.offseason ? league.data.year : prevYear
 
     return (
       <table className="table-auto w-full border-collapse my-4 text-sm">
@@ -121,7 +123,7 @@ const DraftBoard = () => {
           )}
         </thead>
         <tbody>
-          {filteredTeams.map(({ teamNumber, teamName, events, yearEndEpa }) => (
+          {filteredTeams.map(({ teamNumber, teamName, events }) => (
             <tr key={teamNumber}>
               <td className="border px-2 py-1">{teamNumber}</td>
               <td className="border px-2 py-1">{teamName}</td>
@@ -131,15 +133,13 @@ const DraftBoard = () => {
                     {event}
                   </td>
                 ))}
-              <td className="border px-2 py-1">{yearEndEpa}</td>
+              <td className="border px-2 py-1"><TeamEPA teamNumber={teamNumber} year={epaYear} /></td>
             </tr>
           ))}
         </tbody>
       </table>
     )
   }
-
-  const location = useLocation()
 
   return (
     <div className="w-full min-w-[1000px] overflow-x-scroll overflow-y-scroll">
@@ -206,6 +206,17 @@ const DraftBoard = () => {
       {renderAvailableTeams()}
     </div>
   )
+}
+
+const TeamEPA = ({
+  teamNumber,
+  year,
+}: {
+  teamNumber: number
+  year: number
+}) => {
+  const { data } = useStatboticsTeamYear(teamNumber, year)
+  return <>{data ?? 'N/A'}</>
 }
 
 const DraftBoardCard = ({


### PR DESCRIPTION
## Summary
- add hook for fetching EPA from Statbotics team_year API
- display EPA from Statbotics in draft available teams table
- cache team year EPA values for a day
- fix lint issue for `useLocation` hook

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ea6985a4c8326b45c90bd8a33a301