### PR TITLE
Fix league week count style

### DIFF
--- a/frontend/src/routes/drafts/$draftId/leagueWeeks.lazy.tsx
+++ b/frontend/src/routes/drafts/$draftId/leagueWeeks.lazy.tsx
@@ -4,6 +4,7 @@ import { useLeague } from "@/api/useLeague";
 import { useFantasyTeams } from "@/api/useFantasyTeams";
 import { usePicks } from "@/api/usePicks";
 import React from "react";
+import { cn } from "@/lib/utils";
 import {
   Table,
   TableBody,
@@ -50,7 +51,9 @@ export const DraftLeagueWeeksPage = () => {
         <TableRow>
           <TableHead>Fantasy Team</TableHead>
           {weeks.map((w) => (
-            <TableHead key={w}>Week {w}</TableHead>
+            <TableHead key={w} className="text-center">
+              Week {w}
+            </TableHead>
           ))}
         </TableRow>
       </TableHeader>
@@ -68,7 +71,10 @@ export const DraftLeagueWeeksPage = () => {
                 className = "bg-red-300";
               }
               return (
-                <TableCell key={index} className={className}>
+                <TableCell
+                  key={index}
+                  className={cn(className, "text-black text-center")}
+                >
                   {count}
                 </TableCell>
               );

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -9,6 +9,7 @@ import { useMemo, useState } from 'react'
 import { useTeamAvatar } from '@/api/useTeamAvatar'
 import { useAvailableTeams } from '@/api/useAvailableTeams'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import {
   Table,
   TableBody,
@@ -307,7 +308,9 @@ const LeagueWeeksTab = () => {
         <TableRow>
           <TableHead>Fantasy Team</TableHead>
           {weeks.map((w) => (
-            <TableHead key={w}>Week {w}</TableHead>
+            <TableHead key={w} className="text-center">
+              Week {w}
+            </TableHead>
           ))}
         </TableRow>
       </TableHeader>
@@ -328,7 +331,10 @@ const LeagueWeeksTab = () => {
                 className = 'bg-red-300'
               }
               return (
-                <TableCell key={index} className={className}>
+                <TableCell
+                  key={index}
+                  className={cn(className, 'text-black text-center')}
+                >
                   {count}
                 </TableCell>
               )


### PR DESCRIPTION
## Summary
- center Week headers on League Weeks pages
- center week count values and force black text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea7cc9f748326a050160964978804