### PR TITLE
Show EPA on draft cards and in available lists

### DIFF
--- a/frontend/src/routes/leagues/$leagueId/available.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/available.lazy.tsx
@@ -3,14 +3,40 @@ import { useLeague } from "@/api/useLeague";
 import { useLeagueAvailableTeams } from "@/api/useLeagueAvailableTeams";
 import { useStatboticsTeamYears } from "@/api/useStatboticsTeamYears";
 import React from "react";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "../../../components/ui/table";
+import { useTeamAvatar } from "@/api/useTeamAvatar";
+
+const AvailableTeamCard = ({
+  team,
+  year,
+}: {
+  team: { teamNumber: number; teamName: string; events: { week: number }[]; epa: number | null };
+  year: number;
+}) => {
+  const teamAvatar = useTeamAvatar(team.teamNumber.toString(), year);
+  const weeks = team.events
+    .filter((e) => e.week !== 99)
+    .sort((a, b) => a.week - b.week)
+    .map((e) => e.week)
+    .join(', ');
+
+  return (
+    <a
+      href={`https://www.thebluealliance.com/team/${team.teamNumber}/${year}`}
+      target="_blank"
+      className="p-2 border rounded-xl h-16 flex flex-col relative bg-slate-700 hover:bg-slate-800 cursor-pointer text-start"
+    >
+      <p className="text-xl font-bold">{team.teamNumber}</p>
+      {weeks && <p className="text-sm">{weeks}</p>}
+      <p className="text-sm">EPA: {team.epa ?? 'N/A'}</p>
+      {teamAvatar.data?.image && (
+        <img
+          src={`data:image/png;base64,${teamAvatar.data.image}`}
+          className="aspect-square h-50% absolute bottom-0 right-0 rounded"
+        />
+      )}
+    </a>
+  );
+};
 
 export const AvailableTeamsPage = () => {
   const { leagueId } = Route.useParams();
@@ -30,66 +56,42 @@ export const AvailableTeamsPage = () => {
   if (league.isLoading || availableTeams.isLoading) return <div>Loading...</div>;
 
   const weeks = [1, 2, 3, 4, 5];
-  const teamEventsByWeek =
+  const teams =
     availableTeams.data
-      ?.map((team, idx) => {
-        const events = weeks.map((w) => {
-          const ev = team.events.find((e) => e.week === w);
-          return ev ? ev.event_key : "";
-        });
-        return {
-          teamNumber: team.team_number,
-          teamName: team.name,
-          events,
-          epa: teamEpas[idx]?.data ?? null,
-        };
-      })
+      ?.map((team, idx) => ({
+        teamNumber: team.team_number,
+        teamName: team.name,
+        events: team.events,
+        epa: teamEpas[idx]?.data ?? null,
+      }))
       .sort((a, b) => (b.epa ?? -Infinity) - (a.epa ?? -Infinity)) ?? [];
 
   const filteredTeams = league.data?.is_fim
-    ? teamEventsByWeek.filter(({ events }) =>
-        selectedWeeks.some((week) => events[week - 1] !== ""),
-      )
-    : teamEventsByWeek;
+    ? teams.filter(({ events }) => events.some((e) => selectedWeeks.includes(e.week)))
+    : teams;
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead rowSpan={2}>Team #</TableHead>
-          <TableHead rowSpan={2}>Team Name</TableHead>
-          {league.data?.is_fim && <TableHead colSpan={5}>Week</TableHead>}
-          <TableHead rowSpan={2}>{league.data?.is_fim ? prevYear : league.data?.year} EPA</TableHead>
-        </TableRow>
-        {league.data?.is_fim && (
-          <TableRow>
-            {weeks.map((week) => (
-              <TableHead key={week} className="text-center">
-                <label className="flex items-center justify-between gap-2">
-                  <span>{week}</span>
-                  <input
-                    type="checkbox"
-                    checked={selectedWeeks.includes(week)}
-                    onChange={() => toggleWeekSelection(week)}
-                  />
-                </label>
-              </TableHead>
-            ))}
-          </TableRow>
-        )}
-      </TableHeader>
-      <TableBody>
-        {filteredTeams.map(({ teamNumber, teamName, events, epa }) => (
-          <TableRow key={teamNumber}>
-            <TableCell>{teamNumber}</TableCell>
-            <TableCell>{teamName}</TableCell>
-            {league.data?.is_fim &&
-              events.map((ev, idx) => <TableCell key={idx}>{ev}</TableCell>)}
-            <TableCell>{epa ?? "N/A"}</TableCell>
-          </TableRow>
+    <div className="my-4">
+      {league.data?.is_fim && (
+        <div className="flex gap-2 mb-2">
+          {weeks.map((week) => (
+            <label key={week} className="flex items-center gap-2">
+              <span>{week}</span>
+              <input
+                type="checkbox"
+                checked={selectedWeeks.includes(week)}
+                onChange={() => toggleWeekSelection(week)}
+              />
+            </label>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2">
+        {filteredTeams.map((team) => (
+          <AvailableTeamCard key={team.teamNumber} team={team} year={epaYear} />
         ))}
-      </TableBody>
-    </Table>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- display available teams in draft card format
- allow filtering available teams by week
- show EPA on all draft/available team cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS errors due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_686eb676fcf8832690a3129fe7ea2e8b