### PR TITLE
Switch navbar icon to IMG_0413

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The Fantasy Robotics League App is a web platform where users can create leagues
    ```bash
    npm start
    ```
-4. Replace `frontend/public/logo.svg` with your own image to customize the
+4. Replace `frontend/public/IMG_0413.png` with your own image to customize the
    navbar logo.
 
 ### **Database Setup**

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -34,7 +34,7 @@ export const Navbar = () => {
       <ul className="flex gap-4">
         <li>
           <Link to="/" className="flex items-center">
-            <img src="/logo.svg" alt="Fantasy FiM logo" className="w-8 h-8" />
+            <img src="/IMG_0413.png" alt="Fantasy FiM logo" className="w-8 h-8" />
           </Link>
         </li>
         <li className="relative group">


### PR DESCRIPTION
## Summary
- use `IMG_0413.png` as the navbar home icon
- update README to reference the new image

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*
- `npm run build` *(fails: cannot find module '@/lib/utils' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ec4d8808883269716636201343ffc