### PR TITLE
Fix TypeScript errors

### DIFF
--- a/frontend/src/api/useStatboticsTeamYear.ts
+++ b/frontend/src/api/useStatboticsTeamYear.ts
@@ -20,6 +20,6 @@ export const useStatboticsTeamYear = (
       }
     },
     staleTime: 1000 * 60 * 60 * 24,
-    cacheTime: 1000 * 60 * 60 * 24 * 7,
+    gcTime: 1000 * 60 * 60 * 24 * 7,
   });
 };

--- a/frontend/src/api/useStatboticsTeamYears.ts
+++ b/frontend/src/api/useStatboticsTeamYears.ts
@@ -23,6 +23,6 @@ export const useStatboticsTeamYears = (
       enabled: !!team && !!year,
       queryFn: () => fetchTeamYearEPA(team, year as number),
       staleTime: 1000 * 60 * 60 * 24,
-      cacheTime: 1000 * 60 * 60 * 24,
+      gcTime: 1000 * 60 * 60 * 24,
     })),
   });

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -14,6 +14,7 @@ const OffseasonDraftLinks = ({ league }: { league: League }) => {
           <Link
             to="/drafts/$draftId"
             params={{ draftId: draft.draft_id.toString() }}
+            search={{ autoRefreshInterval: false }}
             className="block px-2 py-1 hover:underline"
           >
             {league.league_name}: {draft.event_key}

--- a/frontend/src/routes/drafts/$draftId/leagueWeeks.lazy.tsx
+++ b/frontend/src/routes/drafts/$draftId/leagueWeeks.lazy.tsx
@@ -3,7 +3,6 @@ import { useDraft } from "@/api/useDraft";
 import { useLeague } from "@/api/useLeague";
 import { useFantasyTeams } from "@/api/useFantasyTeams";
 import { usePicks } from "@/api/usePicks";
-import React from "react";
 import { cn } from "@/lib/utils";
 import {
   Table,

--- a/frontend/src/routes/drafts/$draftId/scores.lazy.tsx
+++ b/frontend/src/routes/drafts/$draftId/scores.lazy.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import React from "react";
 
 export const DraftScoresPage = () => {
   const { draftId } = Route.useParams();
@@ -35,7 +34,11 @@ export const DraftScoresPage = () => {
         </h1>
       </div>
       <div className="text-center my-4">
-        <Link to="/drafts/$draftId" params={{ draftId }}>
+        <Link
+          to="/drafts/$draftId"
+          params={{ draftId }}
+          search={{ autoRefreshInterval: false }}
+        >
           <Button>View Draft</Button>
         </Link>
       </div>

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -240,7 +240,7 @@ const DraftBoardCard = ({
             .join(', ')
           : ''}
       </p>
-      <p className="text-sm">EPA: {epa ?? 'N/A'}</p>
+      <p className="text-sm">EPA: {String(epa ?? 'N/A')}</p>
 
       {teamAvatar.data?.image && (
         <img
@@ -273,7 +273,7 @@ const AvailableTeamCard = ({
     >
       <p className="text-xl font-bold">{team.teamNumber}</p>
       {weeks && <p className="text-sm">{weeks}</p>}
-      <p className="text-sm">EPA: {team.epa ?? 'N/A'}</p>
+      <p className="text-sm">EPA: {String(team.epa ?? 'N/A')}</p>
       {teamAvatar.data?.image && (
         <img
           src={`data:image/png;base64,${teamAvatar.data.image}`}

--- a/frontend/src/routes/leagues/$leagueId/waivers.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/waivers.lazy.tsx
@@ -3,7 +3,7 @@ import { useLeague } from "@/api/useLeague";
 import { useWaiverTeams } from "@/api/useWaiverTeams";
 import { useWaiverPriority } from "@/api/useWaiverPriority";
 import { WaiverPriority } from "@/types/WaiverPriority";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTeamAvatar } from "@/api/useTeamAvatar";
 import {
   Table,

--- a/frontend/src/routes/offseasonDrafts.lazy.tsx
+++ b/frontend/src/routes/offseasonDrafts.lazy.tsx
@@ -21,6 +21,7 @@ const OffseasonLeague = ({ league }: { league: League }) => {
             <Link
               to="/drafts/$draftId"
               params={{ draftId: draft.draft_id.toString() }}
+              search={{ autoRefreshInterval: false }}
               className="hover:underline"
             >
               {draft.event_key}


### PR DESCRIPTION
## Summary
- update React Query `cacheTime` options to `gcTime`
- satisfy `Link` prop requirements for routes with search params
- remove unused React imports
- fix EPA display to avoid ReactNode type issues

## Testing
- `pnpm install`
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module '@/lib/utils' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686ecb0ae88883269ad6759f5a2e3909