### PR TITLE
Check for team before inserting Statbotics data

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -115,6 +115,9 @@ class Admin(commands.Cog):
           break
         for team_year in data:
           team_number = str(team_year.get("team"))
+          if session.query(Team).filter(Team.team_number == team_number).count() == 0:
+            logger.warning(f"Skipping team {team_number} - not present in teams table")
+            continue
           unitless_epa = team_year.get("unitless_epa_end")
           if unitless_epa is None:
             epa_end = team_year.get("epa_end")


### PR DESCRIPTION
## Summary
- prevent foreign key errors by verifying a team exists before inserting StatboticsData records

## Testing
- `python -m py_compile cogs/admin.py`

------
https://chatgpt.com/codex/tasks/task_e_686ee26201f48326b6492198bc0236b1