### PR TITLE
Add EPA batch endpoint and refactor frontend

### DIFF
--- a/frontend/src/api/useStatboticsTeamYear.ts
+++ b/frontend/src/api/useStatboticsTeamYear.ts
@@ -9,12 +9,13 @@ export const useStatboticsTeamYear = (
     enabled: !!team && !!year,
     queryFn: async () => {
       const response = await fetch(
-        `https://api.statbotics.io/v3/team_year/${team}/${year}`,
+        `/api/epa?teams=${team}&year=${year}`,
       );
       if (!response.ok) return null;
       try {
         const data = await response.json();
-        return typeof data?.epa?.unitless === "number" ? data.epa.unitless : null;
+        const value = data?.[team as string];
+        return typeof value === "number" ? value : null;
       } catch {
         return null;
       }

--- a/frontend/src/api/useStatboticsTeamYears.ts
+++ b/frontend/src/api/useStatboticsTeamYears.ts
@@ -1,28 +1,24 @@
-import { useQueries } from "@tanstack/react-query";
-
-const fetchTeamYearEPA = async (team: number | string, year: number) => {
-  const response = await fetch(
-    `https://api.statbotics.io/v3/team_year/${team}/${year}`,
-  );
-  if (!response.ok) return null;
-  try {
-    const data = await response.json();
-    return typeof data?.epa?.unitless === "number" ? data.epa.unitless : null;
-  } catch {
-    return null;
-  }
-};
+import { useQuery } from "@tanstack/react-query";
 
 export const useStatboticsTeamYears = (
   teams: (number | string)[],
   year: number | undefined,
 ) =>
-  useQueries({
-    queries: teams.map((team) => ({
-      queryKey: ["statbotics-team-year", team, year],
-      enabled: !!team && !!year,
-      queryFn: () => fetchTeamYearEPA(team, year as number),
-      staleTime: 1000 * 60 * 60 * 24,
-      gcTime: 1000 * 60 * 60 * 24,
-    })),
+  useQuery<Record<string, number | null>>({
+    queryKey: ["statbotics-team-years", teams, year],
+    enabled: teams.length > 0 && !!year,
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/epa?teams=${teams.join(",")}&year=${year}`,
+      );
+      if (!response.ok) return {};
+      try {
+        const data = await response.json();
+        return data as Record<string, number | null>;
+      } catch {
+        return {};
+      }
+    },
+    staleTime: 1000 * 60 * 60 * 24,
+    gcTime: 1000 * 60 * 60 * 24,
   });

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -80,12 +80,13 @@ const DraftBoard = () => {
 
     const weeks = [1, 2, 3, 4, 5]
 
+    const epas = teamEpas.data ?? {}
     const teams = availableTeams.data
-      .map((team, idx) => ({
+      .map((team) => ({
         teamNumber: team.team_number,
         teamName: team.name,
         events: team.events,
-        epa: teamEpas[idx]?.data ?? null,
+        epa: epas[team.team_number] ?? null,
       }))
       .sort((a, b) => (b.epa ?? -Infinity) - (a.epa ?? -Infinity))
 

--- a/frontend/src/routes/leagues/$leagueId/available.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/available.lazy.tsx
@@ -56,13 +56,14 @@ export const AvailableTeamsPage = () => {
   if (league.isLoading || availableTeams.isLoading) return <div>Loading...</div>;
 
   const weeks = [1, 2, 3, 4, 5];
+  const epas = teamEpas.data ?? {};
   const teams =
     availableTeams.data
-      ?.map((team, idx) => ({
+      ?.map((team) => ({
         teamNumber: team.team_number,
         teamName: team.name,
         events: team.events,
-        epa: teamEpas[idx]?.data ?? null,
+        epa: epas[team.team_number] ?? null,
       }))
       .sort((a, b) => (b.epa ?? -Infinity) - (a.epa ?? -Infinity)) ?? [];
 


### PR DESCRIPTION
## Summary
- introduce `/api/epa` endpoint to read cached EPA values for multiple teams
- adapt React hooks to use the new endpoint
- update draft and league views to use returned EPA map

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee3dcb3488326832df550115457c8