### PR TITLE
Conditionally hide devtools

### DIFF
--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -3,6 +3,8 @@ import { TanStackRouterDevtools } from "@tanstack/router-devtools";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import Navbar from "@/components/Navbar";
 
+const showDevtools = import.meta.env.DEV;
+
 export const Route = createRootRoute({
   component: () => (
     <>
@@ -10,8 +12,8 @@ export const Route = createRootRoute({
         <Navbar />
         <Outlet />
       </div>
-      <TanStackRouterDevtools />
-      <ReactQueryDevtools initialIsOpen={false} />
+      {showDevtools && <TanStackRouterDevtools />}
+      {showDevtools && <ReactQueryDevtools initialIsOpen={false} />}
     </>
   ),
 });


### PR DESCRIPTION
## Summary
- hide Router and Query devtools unless `import.meta.env.DEV` is true

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@/lib/utils')*

------
https://chatgpt.com/codex/tasks/task_e_686ef05f82c88326bb33a9b89d2d907f