### PR TITLE
Expose current week via API and default UI behaviour

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,6 +75,54 @@ Base.metadata.create_all(engine)
 
 Session = sessionmaker(bind=engine)
 
+@app.route('/api/currentWeek', methods=['GET'])
+def get_current_week():
+    """
+    Retrieve the currently active week.
+    ---
+    tags:
+      - Weeks
+    responses:
+      200:
+        description: The currently active week.
+        schema:
+          type: object
+          properties:
+            year:
+              type: integer
+              example: 2024
+            week:
+              type: integer
+              example: 1
+            lineups_locked:
+              type: boolean
+            scores_finalized:
+              type: boolean
+            active:
+              type: boolean
+      404:
+        description: No active week found.
+    """
+    session = Session()
+    week = (
+        session.query(WeekStatus)
+        .filter(WeekStatus.active == True)
+        .order_by(WeekStatus.year.asc(), WeekStatus.week.asc())
+        .first()
+    )
+    session.close()
+    if not week:
+        return jsonify({"error": "No active week found"}), 404
+    return jsonify(
+        {
+            "year": week.year,
+            "week": week.week,
+            "lineups_locked": week.lineups_locked,
+            "scores_finalized": week.scores_finalized,
+            "active": week.active,
+        }
+    )
+
 @app.route('/api/leagues', methods=['GET'])
 def get_leagues():
     """

--- a/frontend/src/api/useCurrentWeek.ts
+++ b/frontend/src/api/useCurrentWeek.ts
@@ -1,0 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
+import { WeekStatus } from "../types/WeekStatus";
+
+export const useCurrentWeek = () =>
+  useQuery<WeekStatus>({
+    queryFn: () => fetch('/api/currentWeek').then((res) => res.json()),
+    queryKey: ['currentWeek'],
+  });

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -10,6 +10,7 @@ import { useTeamAvatar } from '@/api/useTeamAvatar'
 import { useAvailableTeams } from '@/api/useAvailableTeams'
 import { useStatboticsTeamYear } from "@/api/useStatboticsTeamYear"
 import { useStatboticsTeamYears } from "@/api/useStatboticsTeamYears"
+import { useCurrentWeek } from "@/api/useCurrentWeek"
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import {
@@ -33,8 +34,16 @@ const DraftBoard = () => {
   const draftOrder = useDraftOrder(draftId)
   const fantasyTeams = useFantasyTeams(league.data?.league_id.toString())
   const availableTeams = useAvailableTeams(draftId)
+  const currentWeek = useCurrentWeek()
   const prevYear = (league.data?.year ?? 0) - 1
-  const epaYear = league.data?.offseason ? league.data?.year : prevYear
+  let epaYear = league.data?.offseason ? league.data?.year : prevYear
+  if (
+    !league.data?.offseason &&
+    currentWeek.data &&
+    currentWeek.data.year === league.data?.year
+  ) {
+    epaYear = currentWeek.data.week === 1 ? prevYear : league.data.year
+  }
   const teamNumbers = availableTeams.data?.map((t) => t.team_number) ?? []
   const teamEpas = useStatboticsTeamYears(teamNumbers, epaYear)
 

--- a/frontend/src/routes/leagues/$leagueId/available.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/available.lazy.tsx
@@ -2,6 +2,7 @@ import { createLazyFileRoute } from "@tanstack/react-router";
 import { useLeague } from "@/api/useLeague";
 import { useLeagueAvailableTeams } from "@/api/useLeagueAvailableTeams";
 import { useStatboticsTeamYears } from "@/api/useStatboticsTeamYears";
+import { useCurrentWeek } from "@/api/useCurrentWeek";
 import React from "react";
 import { useTeamAvatar } from "@/api/useTeamAvatar";
 
@@ -42,8 +43,16 @@ export const AvailableTeamsPage = () => {
   const { leagueId } = Route.useParams();
   const league = useLeague(leagueId);
   const availableTeams = useLeagueAvailableTeams(leagueId);
+  const currentWeek = useCurrentWeek();
   const prevYear = (league.data?.year ?? 0) - 1;
-  const epaYear = league.data?.offseason ? league.data?.year : prevYear;
+  let epaYear = league.data?.offseason ? league.data?.year : prevYear;
+  if (
+    !league.data?.offseason &&
+    currentWeek.data &&
+    currentWeek.data.year === league.data?.year
+  ) {
+    epaYear = currentWeek.data.week === 1 ? prevYear : league.data.year;
+  }
   const teamNumbers = availableTeams.data?.map((t) => t.team_number) ?? [];
   const teamEpas = useStatboticsTeamYears(teamNumbers, epaYear);
   const [selectedWeeks, setSelectedWeeks] = React.useState<number[]>([1, 2, 3, 4, 5]);

--- a/frontend/src/routes/leagues/$leagueId/scores.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/scores.lazy.tsx
@@ -2,6 +2,8 @@ import { createLazyFileRoute } from "@tanstack/react-router";
 import { useLineups } from "@/api/useLineups";
 import { FantasyTeamLineup } from "@/types/FantasyTeamLineup";
 import React from "react";
+import { useLeague } from "@/api/useLeague";
+import { useCurrentWeek } from "@/api/useCurrentWeek";
 import {
   Select,
   SelectContent,
@@ -23,8 +25,21 @@ import { useLineupScore, useTeamScore } from "../../../api/useScore";
 export const ScoresPage = () => {
   const { leagueId } = Route.useParams();
   const lineups = useLineups(leagueId);
+  const league = useLeague(leagueId);
+  const currentWeek = useCurrentWeek();
 
   const [selectedWeek, setSelectedWeek] = React.useState(1);
+
+  React.useEffect(() => {
+    if (
+      currentWeek.data &&
+      league.data &&
+      league.data.year === currentWeek.data.year &&
+      selectedWeek === 1
+    ) {
+      setSelectedWeek(currentWeek.data.week);
+    }
+  }, [currentWeek.data, league.data]);
 
   const maxTeamCount =
     lineups.data

--- a/frontend/src/routes/leagues/$leagueId/waivers.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/waivers.lazy.tsx
@@ -2,6 +2,7 @@ import { createLazyFileRoute } from "@tanstack/react-router";
 import { useLeague } from "@/api/useLeague";
 import { useWaiverTeams } from "@/api/useWaiverTeams";
 import { useWaiverPriority } from "@/api/useWaiverPriority";
+import { useCurrentWeek } from "@/api/useCurrentWeek";
 import { WaiverPriority } from "@/types/WaiverPriority";
 import { useState } from "react";
 import { useTeamAvatar } from "@/api/useTeamAvatar";
@@ -53,6 +54,7 @@ export const WaiversPage = () => {
   const league = useLeague(leagueId);
   const waiverTeams = useWaiverTeams(leagueId);
   const waiverPriority = useWaiverPriority(leagueId);
+  const currentWeek = useCurrentWeek();
 
   const [activeTab, setActiveTab] = useState<'teams' | 'priority'>('teams');
   const [selectedWeeks, setSelectedWeeks] = useState<number[]>([1, 2, 3, 4, 5]);
@@ -76,7 +78,14 @@ export const WaiversPage = () => {
 
     const weeks = [1, 2, 3, 4, 5];
     const prevYear = (league.data.year ?? 0) - 1;
-    const epaYear = league.data.offseason ? league.data.year : prevYear;
+    let epaYear = league.data.offseason ? league.data.year : prevYear;
+    if (
+      !league.data.offseason &&
+      currentWeek.data &&
+      currentWeek.data.year === league.data.year
+    ) {
+      epaYear = currentWeek.data.week === 1 ? prevYear : league.data.year;
+    }
 
     const teams =
       waiverTeams.data

--- a/frontend/src/types/WeekStatus.ts
+++ b/frontend/src/types/WeekStatus.ts
@@ -1,0 +1,7 @@
+export type WeekStatus = {
+  year: number;
+  week: number;
+  lineups_locked: boolean;
+  scores_finalized: boolean;
+  active: boolean;
+};


### PR DESCRIPTION
## Summary
- add `/api/currentWeek` endpoint to return active week
- provide React query hook and WeekStatus type
- default Scores page week to current week when applicable
- adjust EPA year logic for available and waiver teams
- use new week logic in draft available teams

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686eefb4e9648326bbee96e54b03a8c6