### PR TITLE
Lazy load draft page sections

### DIFF
--- a/frontend/src/components/drafts/AvailableTeamsSection.tsx
+++ b/frontend/src/components/drafts/AvailableTeamsSection.tsx
@@ -1,0 +1,122 @@
+import { useState, useMemo } from 'react'
+import { useDraft } from '@/api/useDraft'
+import { useLeague } from '@/api/useLeague'
+import { useAvailableTeams } from '@/api/useAvailableTeams'
+import { useCurrentWeek } from '@/api/useCurrentWeek'
+import { useTeamAvatar } from '@/api/useTeamAvatar'
+
+type AvailableTeamsSectionProps = {
+  draftId: string
+}
+
+const weekOptions = [1, 2, 3, 4, 6]
+
+const AvailableTeamsSection = ({ draftId }: AvailableTeamsSectionProps) => {
+  const [selectedWeeks, setSelectedWeeks] = useState<number[]>([1, 2, 3, 4, 6])
+  const draft = useDraft(draftId)
+  const leagueId = draft.data?.league_id?.toString()
+  const league = useLeague(leagueId)
+  const availableTeams = useAvailableTeams(draftId)
+  const currentWeek = useCurrentWeek()
+
+  const toggleWeekSelection = (week: number) => {
+    setSelectedWeeks((prev) =>
+      prev.includes(week) ? prev.filter((w) => w !== week) : [...prev, week],
+    )
+  }
+
+  const epaYear = useMemo(() => {
+    if (!league.data) {
+      return 0
+    }
+
+    const prevYear = (league.data.year ?? 0) - 1
+    let draftEpaYear = league.data.offseason ? league.data.year : prevYear
+
+    if (
+      !league.data.offseason &&
+      currentWeek.data &&
+      currentWeek.data.year === league.data.year
+    ) {
+      draftEpaYear = currentWeek.data.week === 1 ? prevYear : league.data.year
+    }
+
+    return draftEpaYear
+  }, [currentWeek.data, league.data])
+
+  if (!league.data || !availableTeams.data) {
+    return <div>Loading available teams...</div>
+  }
+
+  const teams = availableTeams.data
+    .map((team) => ({
+      teamNumber: team.team_number,
+      teamName: team.name,
+      events: team.events,
+      epa: team.year_end_epa ?? null,
+    }))
+    .sort((a, b) => (b.epa ?? -Infinity) - (a.epa ?? -Infinity))
+
+  const filteredTeams = league.data.is_fim
+    ? teams.filter(({ events }) => events.some((event) => selectedWeeks.includes(event.week)))
+    : teams
+
+  return (
+    <div className="my-4">
+      <h1 className="text-3xl font-bold text-center">Available Teams</h1>
+      {league.data.is_fim && (
+        <div className="flex gap-2 mb-2 justify-center">
+          {weekOptions.map((week) => (
+            <label key={week} className="flex items-center gap-2">
+              <span>Competes Week {week}</span>
+              <input
+                type="checkbox"
+                checked={selectedWeeks.includes(week)}
+                onChange={() => toggleWeekSelection(week)}
+              />
+            </label>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2 justify-center">
+        {filteredTeams.map((team) => (
+          <AvailableTeamCard key={team.teamNumber} team={team} year={epaYear} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+type AvailableTeamCardProps = {
+  team: { teamNumber: number; teamName: string; events: { week: number }[]; epa: number | null }
+  year: number
+}
+
+const AvailableTeamCard = ({ team, year }: AvailableTeamCardProps) => {
+  const teamAvatar = useTeamAvatar(team.teamNumber.toString(), year)
+  const weeks = team.events
+    .filter((event) => event.week !== 99)
+    .sort((a, b) => a.week - b.week)
+    .map((event) => event.week)
+    .join(', ')
+
+  return (
+    <a
+      href={`https://www.thebluealliance.com/team/${team.teamNumber}/${year}`}
+      target="_blank"
+      className="p-2 border rounded-xl h-20 w-48 flex flex-col relative bg-slate-700 hover:bg-slate-800 cursor-pointer text-start"
+    >
+      <p className="text-xl font-bold">{team.teamNumber}</p>
+      {weeks && <p className="text-sm">{weeks}</p>}
+      <p className="text-sm">EPA: {String(team.epa ?? 'N/A')}</p>
+      {teamAvatar.data?.image && (
+        <img
+          src={`data:image/png;base64,${teamAvatar.data.image}`}
+          className="aspect-square h-50% absolute bottom-0 right-0 rounded"
+        />
+      )}
+    </a>
+  )
+}
+
+export default AvailableTeamsSection

--- a/frontend/src/components/drafts/DraftBoardContent.tsx
+++ b/frontend/src/components/drafts/DraftBoardContent.tsx
@@ -1,0 +1,155 @@
+import { useMemo } from 'react'
+import { useDraft } from '@/api/useDraft'
+import { useLeague } from '@/api/useLeague'
+import { usePicks } from '@/api/usePicks'
+import { useDraftOrder } from '@/api/useDraftOrder'
+import { useFantasyTeams } from '@/api/useFantasyTeams'
+import { DraftPick } from '@/types/DraftPick'
+import { useTeamAvatar } from '@/api/useTeamAvatar'
+import { useStatboticsTeamYear } from '@/api/useStatboticsTeamYear'
+import { useCurrentWeek } from '@/api/useCurrentWeek'
+
+type DraftBoardContentProps = {
+  draftId: string
+  autoRefreshInterval: number | false
+}
+
+const DraftBoardContent = ({
+  draftId,
+  autoRefreshInterval,
+}: DraftBoardContentProps) => {
+  const draft = useDraft(draftId)
+  const leagueId = draft.data?.league_id?.toString()
+  const league = useLeague(leagueId)
+  const picks = usePicks(draftId, autoRefreshInterval)
+  const draftOrder = useDraftOrder(draftId)
+  const fantasyTeams = useFantasyTeams(leagueId)
+  const currentWeek = useCurrentWeek()
+
+  const draftOrderPlayers = useMemo(
+    () =>
+      Array.isArray(draftOrder.data)
+        ? draftOrder.data.map((order) => ({
+            ...order,
+            team: fantasyTeams.data?.find(
+              (t) => t.fantasy_team_id === order.fantasy_team_id,
+            ),
+          }))
+        : [],
+    [draftOrder.data, fantasyTeams.data],
+  )
+
+  const draftOrderData = draftOrder.data
+
+  if (!draft.data || !league.data || !picks.data || !draftOrderData) {
+    return <div>Loading draft board...</div>
+  }
+
+  const prevYear = (league.data.year ?? 0) - 1
+  let epaYear = league.data.offseason ? league.data.year : prevYear
+
+  if (
+    !league.data.offseason &&
+    currentWeek.data &&
+    currentWeek.data.year === league.data.year
+  ) {
+    epaYear = currentWeek.data.week === 1 ? prevYear : league.data.year
+  }
+
+  const totalPicks = draftOrderData.length * (draft.data.rounds ?? 1)
+
+  const draftPicks = [
+    ...(picks.data ?? ([] as DraftPick[])),
+    ...(Array(totalPicks - (picks.data?.length ?? 0)).fill(null) as null[]),
+  ]
+
+  const picksInRound: (DraftPick | null)[][] = []
+  for (let i = 0; i < draftPicks.length; i += draftOrderData.length) {
+    picksInRound.push(draftPicks.slice(i, i + draftOrderData.length))
+  }
+
+  return (
+    <div className="space-y-4">
+      <div
+        className="grid"
+        style={{ gridTemplateColumns: `repeat(${draftOrderData.length}, 1fr)` }}
+      >
+        {draftOrderPlayers?.map((order) => (
+          <div className="text-center mb-4" key={order.fantasy_team_id}>
+            {order.team?.team_name}
+          </div>
+        ))}
+      </div>
+      {picksInRound.map((row, rowIndex) => (
+        <div
+          key={rowIndex}
+          className="grid mb-1 gap-1"
+          style={{
+            gridTemplateColumns: `repeat(${draftOrderData.length}, 1fr)`,
+          }}
+        >
+          {(rowIndex % 2 === 0 ? row : [...row].reverse()).map((pick, colIndex) => (
+            <DraftBoardCard
+              key={rowIndex * draftOrderData.length + colIndex + 1}
+              pick={{ round: rowIndex + 1, pick: colIndex + 1 }}
+              team={pick}
+              displayYear={league.data.year}
+              epaYear={epaYear}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+type DraftBoardCardProps = {
+  pick: { round: number; pick: number }
+  team: DraftPick | null
+  displayYear: number
+  epaYear: number
+}
+
+const DraftBoardCard = ({ pick, team, displayYear, epaYear }: DraftBoardCardProps) => {
+  const teamAvatar = useTeamAvatar(team?.team_picked, displayYear)
+  const { data: epa } = useStatboticsTeamYear(
+    team?.team_picked ? Number(team.team_picked) : undefined,
+    epaYear,
+  )
+
+  return (
+    <a
+      data-round={pick.round}
+      data-pick={pick.pick}
+      href={
+        team?.team_picked !== '-1'
+          ? `https://www.thebluealliance.com/team/${team?.team_picked}/${displayYear}`
+          : '#'
+      }
+      target={team?.team_picked !== '-1' ? '_blank' : '_self'}
+      className="p-2 border rounded-xl h-20 flex flex-col relative bg-slate-700 hover:bg-slate-800 cursor-pointer text-start"
+    >
+      <p className="text-xl font-bold">
+        {team?.team_picked !== '-1' ? team?.team_picked : ''}
+      </p>
+      <p className="text-sm">
+        {Array.isArray(team?.events)
+          ? team.events
+              .filter((event) => event.week !== 99)
+              .sort((a, b) => a.week - b.week)
+              .map((event) => event.week)
+              .join(', ')
+          : ''}
+      </p>
+      <p className="text-sm">EPA: {String(epa ?? 'N/A')}</p>
+      {teamAvatar.data?.image && (
+        <img
+          src={`data:image/png;base64,${teamAvatar.data.image}`}
+          className="aspect-square h-50% absolute bottom-0 right-0 rounded"
+        />
+      )}
+    </a>
+  )
+}
+
+export default DraftBoardContent

--- a/frontend/src/components/drafts/DraftHeader.tsx
+++ b/frontend/src/components/drafts/DraftHeader.tsx
@@ -1,0 +1,64 @@
+import { Link } from '@tanstack/react-router'
+import { useDraft } from '@/api/useDraft'
+import { useLeague } from '@/api/useLeague'
+import { Button } from '@/components/ui/button'
+import { useEffect } from 'react'
+
+type DraftHeaderProps = {
+  draftId: string
+  tab: 'draft' | 'leagueWeeks'
+  onTabChange: (tab: 'draft' | 'leagueWeeks') => void
+}
+
+const DraftHeader = ({ draftId, tab, onTabChange }: DraftHeaderProps) => {
+  const draft = useDraft(draftId)
+  const leagueId = draft.data?.league_id?.toString()
+  const league = useLeague(leagueId)
+
+  useEffect(() => {
+    if (league.data?.offseason) {
+      onTabChange('draft')
+    }
+  }, [league.data?.offseason, onTabChange])
+
+  if (draft.isLoading || league.isLoading || !league.data) {
+    return <div className="flex flex-col items-center">Loading draft...</div>
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      <h1 className="text-3xl font-bold text-center">{league.data.league_name}</h1>
+      {!league.data.offseason && (
+        <div className="flex gap-2 mt-2">
+          <Button
+            variant={tab === 'draft' ? 'default' : 'outline'}
+            onClick={() => onTabChange('draft')}
+          >
+            Draft
+          </Button>
+          <Button
+            variant={tab === 'leagueWeeks' ? 'default' : 'outline'}
+            onClick={() => onTabChange('leagueWeeks')}
+          >
+            League Weeks
+          </Button>
+          <Link
+            to="/leagues/$leagueId"
+            params={{ leagueId: league.data.league_id.toString() }}
+          >
+            <Button variant="outline">Back to League</Button>
+          </Link>
+        </div>
+      )}
+      {league.data.offseason && (
+        <div className="text-center my-4">
+          <Link to="/drafts/$draftId/scores" params={{ draftId }}>
+            <Button>View Draft Scores</Button>
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default DraftHeader

--- a/frontend/src/components/drafts/LeagueWeeksTab.tsx
+++ b/frontend/src/components/drafts/LeagueWeeksTab.tsx
@@ -1,0 +1,76 @@
+import { useDraft } from '@/api/useDraft'
+import { useLeague } from '@/api/useLeague'
+import { usePicks } from '@/api/usePicks'
+import { useFantasyTeams } from '@/api/useFantasyTeams'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+
+type LeagueWeeksTabProps = {
+  draftId: string
+}
+
+const LeagueWeeksTab = ({ draftId }: LeagueWeeksTabProps) => {
+  const draft = useDraft(draftId)
+  const leagueId = draft.data?.league_id?.toString()
+  const league = useLeague(leagueId)
+  const draftPicks = usePicks(draftId)
+  const fantasyTeams = useFantasyTeams(leagueId)
+
+  if (draft.isLoading || league.isLoading || draftPicks.isLoading || fantasyTeams.isLoading) {
+    return <div>Loading...</div>
+  }
+
+  const fantasyTeamWeekCounts: Record<number, number[]> = {}
+  fantasyTeams.data?.forEach((team) => {
+    fantasyTeamWeekCounts[team.fantasy_team_id] = [0, 0, 0, 0, 0]
+  })
+
+  draftPicks.data?.forEach((pick) => {
+    pick.events.forEach((event) => {
+      if (event.week >= 1 && event.week <= 6) {
+        fantasyTeamWeekCounts[pick.fantasy_team_id][event.week - 1] += 1
+      }
+    })
+  })
+
+  const weeks = [1, 2, 3, 4, 6]
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Fantasy Team</TableHead>
+          {weeks.map((week) => (
+            <TableHead key={week} className="text-center">
+              Week {week}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {fantasyTeams.data?.map((team) => (
+          <TableRow key={team.fantasy_team_id}>
+            <TableCell className="font-bold">{team.team_name}</TableCell>
+            {fantasyTeamWeekCounts[team.fantasy_team_id].map((count, index) => {
+              let className = ''
+              if (league.data && count >= league.data.weekly_starts) {
+                className = 'bg-green-300'
+              } else if (league.data && count === league.data.weekly_starts - 1) {
+                className = 'bg-yellow-300'
+              } else {
+                className = 'bg-red-300'
+              }
+              return (
+                <TableCell key={index} className={cn(className, 'text-black text-center')}>
+                  {count}
+                </TableCell>
+              )
+            })}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+export default LeagueWeeksTab

--- a/frontend/src/routes/drafts/_.$draftId.tsx
+++ b/frontend/src/routes/drafts/_.$draftId.tsx
@@ -1,381 +1,51 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
-import { useDraft } from '@/api/useDraft'
-import { useLeague } from '@/api/useLeague'
-import { usePicks } from '@/api/usePicks'
-import { useDraftOrder } from '@/api/useDraftOrder'
-import { DraftPick } from '@/types/DraftPick'
-import { useFantasyTeams } from '@/api/useFantasyTeams'
-import { useMemo, useState } from 'react'
-import { useTeamAvatar } from '@/api/useTeamAvatar'
-import { useAvailableTeams } from '@/api/useAvailableTeams'
-import { useStatboticsTeamYear } from "@/api/useStatboticsTeamYear"
-import { useCurrentWeek } from "@/api/useCurrentWeek"
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
+import { createFileRoute } from '@tanstack/react-router'
+import { Suspense, lazy, useState } from 'react'
 
-const DraftBoard = () => {
+const DraftHeader = lazy(() => import('@/components/drafts/DraftHeader'))
+const DraftBoardContent = lazy(() => import('@/components/drafts/DraftBoardContent'))
+const AvailableTeamsSection = lazy(() => import('@/components/drafts/AvailableTeamsSection'))
+const LeagueWeeksTab = lazy(() => import('@/components/drafts/LeagueWeeksTab'))
+
+type DraftTab = 'draft' | 'leagueWeeks'
+
+const DraftPage = () => {
   const { draftId } = Route.useParams()
-
-  // Pull the auto refresh interval from the query string
   const { autoRefreshInterval } = Route.useSearch()
-
-  const draft = useDraft(draftId)
-  const league = useLeague(draft.data?.league_id.toString())
-  const picks = usePicks(draftId, autoRefreshInterval)
-  const draftOrder = useDraftOrder(draftId)
-  const fantasyTeams = useFantasyTeams(league.data?.league_id.toString())
-  const availableTeams = useAvailableTeams(draftId)
-  const currentWeek = useCurrentWeek()
-  const prevYear = (league.data?.year ?? 0) - 1
-  let epaYear = league.data?.offseason ? league.data?.year : prevYear
-  if (
-    !league.data?.offseason &&
-    currentWeek.data &&
-    currentWeek.data.year === league.data?.year
-  ) {
-    epaYear = currentWeek.data.week === 1 ? prevYear : league.data.year
-  }
-
-
-  const [selectedWeeks, setSelectedWeeks] = useState<number[]>([1, 2, 3, 4, 6])
-  const [tab, setTab] = useState<'draft' | 'leagueWeeks'>('draft')
-
-  const toggleWeekSelection = (week: number) => {
-    setSelectedWeeks((prev) =>
-      prev.includes(week) ? prev.filter((w) => w !== week) : [...prev, week],
-    )
-  }
-
-  const draftOrderPlayers = useMemo(
-    () =>
-      Array.isArray(draftOrder.data)
-        ? draftOrder.data.map((order) => ({
-            ...order,
-            team: fantasyTeams.data?.find(
-              (t) => t.fantasy_team_id === order.fantasy_team_id,
-            ),
-          }))
-        : [],
-    [draftOrder.data, fantasyTeams.data],
-  )
-
-  if (!draft.data || !league.data || !picks.data || !draftOrder.data) {
-    return <div>Loading...</div>
-  }
-
-  const totalPicks = (draftOrder.data?.length ?? 1) * (draft.data?.rounds ?? 1)
-
-  const draftPicks = [
-    ...(picks.data ?? ([] as DraftPick[])),
-    ...(Array(totalPicks - (picks.data?.length ?? 0)).fill(null) as null[]),
-  ]
-  const picksInRound: (DraftPick | null)[][] = []
-  for (let i = 0; i < draftPicks.length; i += draftOrder.data?.length ?? 1) {
-    picksInRound.push(draftPicks.slice(i, i + (draftOrder.data?.length ?? 1)))
-  }
-
-  const renderAvailableTeams = () => {
-    if (!availableTeams.data || !league.data) return null
-
-    const weeks = [1, 2, 3, 4, 6]
-
-    const teams = availableTeams.data
-      .map((team) => ({
-        teamNumber: team.team_number,
-        teamName: team.name,
-        events: team.events,
-        epa: team.year_end_epa ?? null,
-      }))
-      .sort((a, b) => (b.epa ?? -Infinity) - (a.epa ?? -Infinity))
-
-    const filteredTeams = league.data.is_fim
-      ? teams.filter(({ events }) =>
-          events.some((e) => selectedWeeks.includes(e.week)),
-        )
-      : teams
-
-    return (
-      <div className="my-4">
-        {league.data.is_fim && (
-          <div className="flex gap-2 mb-2">
-            {weeks.map((week) => (
-              <label key={week} className="flex items-center gap-2">
-                <span>Competes Week {week}</span>
-                <input
-                  type="checkbox"
-                  checked={selectedWeeks.includes(week)}
-                  onChange={() => toggleWeekSelection(week)}
-                />
-              </label>
-            ))}
-          </div>
-        )}
-        <div className="flex flex-wrap gap-2">
-          {filteredTeams.map((team) => (
-            <AvailableTeamCard
-              key={team.teamNumber}
-              team={team}
-              year={epaYear}
-            />
-          ))}
-        </div>
-      </div>
-    )
-  }
+  const [tab, setTab] = useState<DraftTab>('draft')
 
   return (
     <div className="w-full min-w-[1000px] overflow-x-scroll overflow-y-scroll">
-      <div className="flex flex-col items-center">
-        <h1 className="text-3xl font-bold text-center">{league.data?.league_name}</h1>
-        {league.data && !league.data.offseason && (
-          <div className="flex gap-2 mt-2">
-            <Button
-              variant={tab === 'draft' ? 'default' : 'outline'}
-              onClick={() => setTab('draft')}
-            >
-              Draft
-            </Button>
-            <Button
-              variant={tab === 'leagueWeeks' ? 'default' : 'outline'}
-              onClick={() => setTab('leagueWeeks')}
-            >
-              League Weeks
-            </Button>
-            <Link to="/leagues/$leagueId" params={{ leagueId: league.data.league_id.toString() }}>
-              <Button variant="outline">Back to League</Button>
-            </Link>
-          </div>
-        )}
-      </div>
-      {league.data.offseason && (
-        <div className="text-center my-4">
-          <Link to="/drafts/$draftId/scores" params={{ draftId }}>
-            <Button>View Draft Scores</Button>
-          </Link>
-        </div>
-      )}
-
-      {tab === 'draft' && (
+      <Suspense fallback={<div>Loading draft information...</div>}>
+        <DraftHeader draftId={draftId} tab={tab} onTabChange={setTab} />
+      </Suspense>
+      {tab === 'draft' ? (
         <>
-          <div
-            className={`grid`}
-            style={{
-              gridTemplateColumns: `repeat(${draftOrder.data?.length ?? 1}, 1fr)`,
-            }}
-          >
-            {draftOrderPlayers?.map((order) => (
-              <div className="text-center mb-4" key={order.fantasy_team_id}>
-                {order.team?.team_name}
-              </div>
-            ))}
-          </div>
-          {picksInRound.map((row, rowIndex) => (
-            <div
-              key={rowIndex}
-              className="grid mb-1 gap-1"
-              style={{
-                gridTemplateColumns: `repeat(${draftOrder.data?.length ?? 1}, 1fr)`,
-              }}
-            >
-              {(rowIndex % 2 === 0 ? row : [...row].reverse()).map(
-                (pick, colIndex) => (
-                  <DraftBoardCard
-                    key={
-                      rowIndex * (draftOrder.data?.length ?? 1) + colIndex + 1
-                    }
-                    pick={{ round: rowIndex + 1, pick: colIndex + 1 }}
-                    team={pick}
-                    displayYear={league.data?.year}
-                    epaYear={epaYear}
-                  />
-                ),
-              )}
-            </div>
-          ))}
-           <h1 className="text-3xl font-bold text-center">Available Teams</h1>
-          {renderAvailableTeams()}
+          <Suspense fallback={<div>Loading draft board...</div>}>
+            <DraftBoardContent
+              draftId={draftId}
+              autoRefreshInterval={autoRefreshInterval ?? false}
+            />
+          </Suspense>
+          <Suspense fallback={<div>Loading available teams...</div>}>
+            <AvailableTeamsSection draftId={draftId} />
+          </Suspense>
         </>
+      ) : (
+        <Suspense fallback={<div>Loading league weeks...</div>}>
+          <LeagueWeeksTab draftId={draftId} />
+        </Suspense>
       )}
-
-      {tab === 'leagueWeeks' && <LeagueWeeksTab />}
     </div>
   )
 }
 
-const DraftBoardCard = ({
-  pick,
-  team,
-  displayYear,
-  epaYear,
-}: {
-  pick: { round: number; pick: number }
-  team: DraftPick | null
-  displayYear: number
-  epaYear: number
-}) => {
-  const teamAvatar = useTeamAvatar(team?.team_picked, displayYear)
-  const { data: epa } = useStatboticsTeamYear(
-    team?.team_picked ? Number(team.team_picked) : undefined,
-    epaYear,
-  )
-  return (
-    <a
-      data-round={pick.round}
-      data-pick={pick.pick}
-      href={
-        team?.team_picked !== '-1'
-          ? `https://www.thebluealliance.com/team/${team?.team_picked}/${displayYear}`
-          : '#'
-      }
-      target={team?.team_picked !== '-1' ? '_blank' : '_self'}
-      className="p-2 border rounded-xl h-20 flex flex-col relative bg-slate-700 hover:bg-slate-800 cursor-pointer text-start"
-    >
-      <p className="text-xl font-bold">
-        {team?.team_picked !== '-1' ? team?.team_picked : ''}
-      </p>
-      <p className="text-sm">
-      {Array.isArray(team?.events)
-        ? team.events
-            .filter((event) => event.week !== 99)
-            .sort((a, b) => a.week - b.week)
-            .map((event) => event.week)
-            .join(', ')
-          : ''}
-      </p>
-      <p className="text-sm">EPA: {String(epa ?? 'N/A')}</p>
-
-      {teamAvatar.data?.image && (
-        <img
-          src={`data:image/png;base64,${teamAvatar.data.image}`}
-          className="aspect-square h-50% absolute bottom-0 right-0 rounded"
-        />
-      )}
-    </a>
-  )
-}
-
-const AvailableTeamCard = ({
-  team,
-  year,
-}: {
-  team: { teamNumber: number; teamName: string; events: { week: number }[]; epa: number | null }
-  year: number
-}) => {
-  const teamAvatar = useTeamAvatar(team.teamNumber.toString(), year)
-  const weeks = team.events
-    .filter((e) => e.week !== 99)
-    .sort((a, b) => a.week - b.week)
-    .map((e) => e.week)
-    .join(', ')
-  return (
-    <a
-      href={`https://www.thebluealliance.com/team/${team.teamNumber}/${year}`}
-      target="_blank"
-      className="p-2 border rounded-xl h-20 w-48 flex flex-col relative bg-slate-700 hover:bg-slate-800 cursor-pointer text-start"
-    >
-      <p className="text-xl font-bold">{team.teamNumber}</p>
-      {weeks && <p className="text-sm">{weeks}</p>}
-      <p className="text-sm">EPA: {String(team.epa ?? 'N/A')}</p>
-      {teamAvatar.data?.image && (
-        <img
-          src={`data:image/png;base64,${teamAvatar.data.image}`}
-          className="aspect-square h-50% absolute bottom-0 right-0 rounded"
-        />
-      )}
-    </a>
-  )
-}
-
-const LeagueWeeksTab = () => {
-  const { draftId } = Route.useParams()
-  const draft = useDraft(draftId)
-  const league = useLeague(draft.data?.league_id.toString())
-  const draftPicks = usePicks(draftId)
-  const fantasyTeams = useFantasyTeams(league.data?.league_id.toString())
-
-  if (
-    draft.isLoading ||
-    league.isLoading ||
-    draftPicks.isLoading ||
-    fantasyTeams.isLoading
-  ) {
-    return <div>Loading...</div>
-  }
-
-  const fantasyTeamWeekCounts: Record<number, number[]> = {}
-  fantasyTeams.data?.forEach((team) => {
-    fantasyTeamWeekCounts[team.fantasy_team_id] = [0, 0, 0, 0, 0]
-  })
-
-  draftPicks.data?.forEach((pick) => {
-    pick.events.forEach((event) => {
-      if (event.week >= 1 && event.week <= 6) {
-        fantasyTeamWeekCounts[pick.fantasy_team_id][event.week - 1] += 1
-      }
-    })
-  })
-
-  const weeks = [1, 2, 3, 4, 6]
-
-  return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Fantasy Team</TableHead>
-          {weeks.map((w) => (
-            <TableHead key={w} className="text-center">
-              Week {w}
-            </TableHead>
-          ))}
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {fantasyTeams.data?.map((team) => (
-          <TableRow key={team.fantasy_team_id}>
-            <TableCell className="font-bold">{team.team_name}</TableCell>
-            {fantasyTeamWeekCounts[team.fantasy_team_id].map((count, index) => {
-              let className = ''
-              if (league.data && count >= league.data.weekly_starts) {
-                className = 'bg-green-300'
-              } else if (
-                league.data &&
-                count === league.data.weekly_starts - 1
-              ) {
-                className = 'bg-yellow-300'
-              } else {
-                className = 'bg-red-300'
-              }
-              return (
-                <TableCell
-                  key={index}
-                  className={cn(className, 'text-black text-center')}
-                >
-                  {count}
-                </TableCell>
-              )
-            })}
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
-  )
-}
-
 export const Route = createFileRoute('/drafts//$draftId')({
-  component: DraftBoard,
+  component: DraftPage,
   validateSearch: (search: Record<string, unknown>) => {
     return {
       autoRefreshInterval: search?.autoRefreshInterval
         ? Number(search.autoRefreshInterval)
-        : false as const,
+        : (false as const),
     }
   },
 })


### PR DESCRIPTION
## Summary
- split the draft route into lazy-loaded header, board, available teams, and league weeks components
- move the draft board, available teams, and league weeks implementations into dedicated component modules for separate loading

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3de1edc1c8326a5e90f6c1f2d150a