### PR TITLE
Align available team cards to the left

### DIFF
--- a/frontend/src/components/drafts/AvailableTeamsSection.tsx
+++ b/frontend/src/components/drafts/AvailableTeamsSection.tsx
@@ -78,7 +78,7 @@ const AvailableTeamsSection = ({ draftId }: AvailableTeamsSectionProps) => {
           ))}
         </div>
       )}
-      <div className="flex flex-wrap gap-2 justify-center">
+      <div className="flex flex-wrap gap-2 justify-start">
         {filteredTeams.map((team) => (
           <AvailableTeamCard key={team.teamNumber} team={team} year={epaYear} />
         ))}


### PR DESCRIPTION
## Summary
- update the available teams section layout so the team cards are left aligned instead of centered for a more standard grid presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd598d8fbc832691f688e0ec56e3b4