### PR TITLE
Fix MissingGreenlet during score update notifications

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -10,6 +10,7 @@ import requests
 from discord import Embed, app_commands
 from discord.ext import commands
 from sqlalchemy import delete, or_, select, update
+from sqlalchemy.orm import selectinload
 
 import cogs.drafting as drafting
 import cogs.manageteam as manageteam
@@ -1245,6 +1246,7 @@ class Admin(commands.Cog):
             for league in leagues:
                 scores_result = await session.execute(
                     select(FantasyScores)
+                    .options(selectinload(FantasyScores.fantasyTeam))
                     .where(
                         FantasyScores.league_id == league.league_id,
                         FantasyScores.week == week,
@@ -1309,6 +1311,7 @@ class Admin(commands.Cog):
             if league:
                 scores_result = await session.execute(
                     select(FantasyScores)
+                    .options(selectinload(FantasyScores.fantasyTeam))
                     .where(
                         FantasyScores.league_id == league.league_id,
                         FantasyScores.event_key == frcEvent.event_key,


### PR DESCRIPTION
### Motivation
- Avoid `MissingGreenlet` errors when building score notification embeds by preventing SQLAlchemy from attempting lazy-loading in async code paths that dereference `team_score.fantasyTeam` outside of a greenlet.

### Description
- Import `selectinload` from `sqlalchemy.orm` and add `.options(selectinload(FantasyScores.fantasyTeam))` to the queries in `notifyWeeklyScoresTask` and `notifySingleDraftTask` so `FantasyScores.fantasyTeam` is eager-loaded before the async message construction.

### Testing
- Ran `python -m py_compile cogs/admin.py` to validate syntax and the file compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af5ad9611483268dbcac868b93c142)