### PR TITLE
Fix MissingGreenlet during waiver processing

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -2499,6 +2499,7 @@ class Admin(commands.Cog):
                             waiverPriorities_result = await session.execute(
                                 select(WaiverPriority)
                                 .where(WaiverPriority.league_id == league.league_id)
+                                .options(selectinload(WaiverPriority.fantasy_team))
                                 .order_by(WaiverPriority.priority.asc())
                             )
                             waiverPrioritiesList = (
@@ -2509,6 +2510,7 @@ class Admin(commands.Cog):
                                 waiverPriorities_result = await session.execute(
                                     select(WaiverPriority)
                                     .where(WaiverPriority.league_id == league.league_id)
+                                    .options(selectinload(WaiverPriority.fantasy_team))
                                     .order_by(WaiverPriority.priority.asc())
                                 )
                                 waiverPrioritiesList = (


### PR DESCRIPTION
### Motivation
- Prevent `MissingGreenlet` errors caused by async lazy-loading of `WaiverPriority.fantasy_team` when `processWaivers` accesses `priorityToCheck.fantasy_team` inside the async processing loop.

### Description
- Eager-load the related `FantasyTeam` by adding `.options(selectinload(WaiverPriority.fantasy_team))` to the `select(WaiverPriority)` queries in `cogs/admin.py` used by `processWaivers`.

### Testing
- Ran `python -m compileall cogs/admin.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b16cffe2a083269ac3d7d11c045bcd)