### PR TITLE
Allow week 6 event starts during 2026 week 5

### DIFF
--- a/cogs/manageteam.py
+++ b/cogs/manageteam.py
@@ -213,9 +213,14 @@ class ManageTeam(commands.Cog):
                 result_message = "Already starting max number of teams this week."
             else:
                 # get frc events in fim this week
+                event_weeks = [week]
+                # 2026 special case: for week 5 lineups, allow teams competing in week 6.
+                if league.year == 2026 and week == 5:
+                    event_weeks.append(6)
+
                 stmt = select(FRCEvent).where(
                     FRCEvent.year == league.year,
-                    FRCEvent.week == week,
+                    FRCEvent.week.in_(event_weeks),
                     FRCEvent.is_fim,
                 )
                 result = await session.execute(stmt)


### PR DESCRIPTION
### Motivation
- For the 2026 season only, allow teams that are competing in week 6 to be started when managers set lineups for week 5.

### Description
- Updated `startTeamTask` in `cogs/manageteam.py` to build `event_weeks = [week]` and append `6` when `league.year == 2026 and week == 5`, and changed the event query to use `FRCEvent.week.in_(event_weeks)` so week 6 FiM events are considered for that special case.

### Testing
- Ran `python -m compileall cogs/manageteam.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c14ee21ccc8326b5f036c7decbf70e)