### PR TITLE
Include week 6 events when scoring 2026 week 5

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -859,17 +859,25 @@ class Admin(commands.Cog):
             elif weekStatus.scores_finalized:
                 await message.edit(content="Scores are already finalized.")
                 return
+            event_weeks = [week]
+            # 2026 special case: week 5 scoring should also pull week 6 events.
+            if year == 2026 and week == 5:
+                event_weeks.append(6)
+
             events_result = await session.execute(
                 select(FRCEvent).where(
                     FRCEvent.year == year,
                     FRCEvent.is_fim,
-                    FRCEvent.week == week,
+                    FRCEvent.week.in_(event_weeks),
                 )
             )
             eventsToScore = events_result.scalars().all()
+            scored_weeks_text = (
+                "weeks 5 and 6" if year == 2026 and week == 5 else f"week {week}"
+            )
             embed = Embed(
                 title=f"Scoring week {week} for {year}",
-                description=f"Importing event info for all {year} week {week} districts from The Blue Alliance",
+                description=f"Importing event info for all {year} {scored_weeks_text} districts from The Blue Alliance",
             )
             await message.edit(content="", embed=embed)
             embed.description = ""


### PR DESCRIPTION
### Motivation
- Ensure fantasy scoring for 2026 week 5 also includes teams competing in week 6 so scores reflect events spanning both weeks.

### Description
- Updated `scoreWeekTask` to set `event_weeks = [week]` and append `6` when `year == 2026 and week == 5`, changed the `FRCEvent` query to use `FRCEvent.week.in_(event_weeks)`, and adjusted the progress embed to say "weeks 5 and 6" for this special case.

### Testing
- Ran `python -m compileall cogs/admin.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1561ad2188326935e9b2959414773)