### PR TITLE
Handle 2026 week 6 start-team requests with guidance

### DIFF
--- a/cogs/manageteam.py
+++ b/cogs/manageteam.py
@@ -185,6 +185,13 @@ class ManageTeam(commands.Cog):
                 if update_response:
                     await deferred.edit(content=result_message)
                 return result_message
+            if league.year == 2026 and week == 6:
+                result_message = (
+                    "Week 6 starts for 2026 are managed under week 5 only. Please try again using week 5."
+                )
+                if update_response:
+                    await deferred.edit(content=result_message)
+                return result_message
             # do you own the team?
             stmt = select(TeamOwned).where(
                 TeamOwned.team_key == frcteam,


### PR DESCRIPTION
### Motivation
- Prevent users from attempting to start teams for 2026 week 6 directly and provide a clear instruction to use week 5 since 2026 week 6 is managed under week 5.

### Description
- Add an early-return guard in `startTeamTask` in `cogs/manageteam.py` that checks `league.year == 2026 and week == 6` and replies `"Week 6 starts for 2026 are managed under week 5 only. Please try again using week 5."` before ownership and start validation.

### Testing
- Ran `python -m py_compile cogs/manageteam.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd73f4996c8326aa0cfaf6df0c1288)