### PR TITLE
Handle week 6 waivers when finishing week 5

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -85,12 +85,17 @@ class Admin(commands.Cog):
                 )
                 return
 
+            event_weeks = [currentWeek.week]
+            # 2026 special case: when finishing week 5, also waive week 6 teams.
+            if currentWeek.year == 2026 and currentWeek.week == 5:
+                event_weeks.append(6)
+
             for league in leagues:
                 competing_result = await session.execute(
                     select(TeamScore.team_key)
                     .join(Team, Team.team_number == TeamScore.team_key)
                     .join(FRCEvent, TeamScore.event_key == FRCEvent.event_key)
-                    .where(Team.is_fim, FRCEvent.week == currentWeek.week)
+                    .where(Team.is_fim, FRCEvent.week.in_(event_weeks))
                     .where(FRCEvent.year == currentWeek.year)
                 )
                 competing_teams = competing_result.all()


### PR DESCRIPTION
### Motivation
- When finishing an active week, week 5 of 2026 should also place teams competing in week 6 on waivers so those multi-week events are handled correctly.

### Description
- Build an `event_weeks` list from the active week and add `6` for the 2026 week-5 special case, and change the competing-team query to use `FRCEvent.week.in_(event_weeks)` instead of matching a single week.

### Testing
- Ran `python -m compileall cogs/admin.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de650f7a1c8326a05bb0e96bbfcacd)