### PR TITLE
Batch registration change logs per event

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -600,8 +600,7 @@ class Admin(commands.Cog):
                                 for score in scores_result.scalars().all()
                             }
 
-                            teamRegistrationChangeEmbed = None
-                            teamRegistrationChangeMsg = None
+                            registration_changes = []
 
                             for team in teams_payload:
                                 teamNumber = str(team.get("team_number"))
@@ -620,27 +619,7 @@ class Admin(commands.Cog):
                                     change_text = (
                                         f"Team {teamNumber} registered for {eventKey}"
                                     )
-                                    if teamRegistrationChangeMsg is None:
-                                        teamRegistrationChangeMsg = (
-                                            await self.bot.log_message(
-                                                f"{eventKey} registration changes",
-                                                change_text,
-                                            )
-                                        )
-                                        teamRegistrationChangeEmbed = Embed(
-                                            title=f"{eventKey} registration changes",
-                                            description=change_text,
-                                        )
-                                        await teamRegistrationChangeMsg.edit(
-                                            embed=teamRegistrationChangeEmbed
-                                        )
-                                    else:
-                                        teamRegistrationChangeEmbed.description += (
-                                            f"\n{change_text}"
-                                        )
-                                        await teamRegistrationChangeMsg.edit(
-                                            embed=teamRegistrationChangeEmbed
-                                        )
+                                    registration_changes.append(change_text)
                                 else:
                                     existing_scores.pop(teamNumber, None)
 
@@ -652,27 +631,20 @@ class Admin(commands.Cog):
                                 change_text = (
                                     f"Team {teamNumber} un-registered from {eventKey}"
                                 )
-                                if teamRegistrationChangeMsg is None:
-                                    teamRegistrationChangeMsg = (
-                                        await self.bot.log_message(
-                                            f"{eventKey} registration changes",
-                                            change_text,
-                                        )
-                                    )
-                                    teamRegistrationChangeEmbed = Embed(
-                                        title=f"{eventKey} registration changes",
-                                        description=change_text,
-                                    )
-                                    await teamRegistrationChangeMsg.edit(
-                                        embed=teamRegistrationChangeEmbed
-                                    )
-                                else:
-                                    teamRegistrationChangeEmbed.description += (
-                                        f"\n{change_text}"
-                                    )
-                                    await teamRegistrationChangeMsg.edit(
-                                        embed=teamRegistrationChangeEmbed
-                                    )
+                                registration_changes.append(change_text)
+
+                            if registration_changes:
+                                all_changes_text = "\n".join(registration_changes)
+                                teamRegistrationChangeMsg = await self.bot.log_message(
+                                    f"{eventKey} registration changes", all_changes_text
+                                )
+                                teamRegistrationChangeEmbed = Embed(
+                                    title=f"{eventKey} registration changes",
+                                    description=all_changes_text,
+                                )
+                                await teamRegistrationChangeMsg.edit(
+                                    embed=teamRegistrationChangeEmbed
+                                )
 
                     await session.commit()
 


### PR DESCRIPTION
### Motivation
- Reduce noisy repeated edits when importing event team registrations by sending a single consolidated message per event instead of appending and editing the log on every team change.

### Description
- Replaced the per-team incremental log/edit flow with an in-memory `registration_changes` list in `cogs/admin.py` that accumulates registration and un-registration lines while processing an event.
- After processing all teams for an event the code now joins the collected lines and sends one log message via `self.bot.log_message` and one `Embed` update for the entire event.
- Removed the repeated `edit` calls that appended to an existing embed for each team change, preserving the original log/embed format but sent once per event.

### Testing
- Ran `python -m compileall cogs/admin.py` to validate syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de65d265888326b97188443e802b06)