### PR TITLE
Fix week 7 (States) visibility in lineups API and frontend selector

### DIFF
--- a/app.py
+++ b/app.py
@@ -838,12 +838,25 @@ def get_lineups(leagueId):
     """
     try:
         with Session() as session:
+            league = session.query(League).filter(League.league_id == leagueId).first()
+            if not league:
+                return jsonify({"error": "League not found"}), 404
+
             # Query to get all fantasy teams for the given league
             fantasy_teams = (
                 session.query(FantasyTeam)
                 .filter(FantasyTeam.league_id == leagueId)
                 .all()
             )
+
+            # Query to get all configured weeks for the league year.
+            configured_weeks = [
+                row.week
+                for row in session.query(WeekStatus.week)
+                .filter(WeekStatus.year == league.year)
+                .order_by(WeekStatus.week.asc())
+                .all()
+            ]
 
             # Query to get all team started records for the given league
             started_teams = (
@@ -856,10 +869,19 @@ def get_lineups(leagueId):
                 .all()
             )
 
+            # Keep backwards compatibility for leagues missing weekstatus rows.
+            if configured_weeks:
+                weeks_to_render = configured_weeks
+            else:
+                max_started_week = max(
+                    (started_team.week for started_team in started_teams), default=7
+                )
+                weeks_to_render = list(range(1, max_started_week + 1))
+
             # Organizing the output by week
             output = {}
 
-            for week in range(1, 7):  # Weeks 1 to 6 (including MSC week)
+            for week in weeks_to_render:
                 output[week] = {"week": week, "fantasy_teams": []}
 
                 # Populate each fantasy team entry

--- a/frontend/src/routes/leagues/$leagueId/scores.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/scores.lazy.tsx
@@ -59,9 +59,9 @@ export const ScoresPage = () => {
           <SelectValue placeholder="Select Week" />
         </SelectTrigger>
         <SelectContent>
-          {Array.from({ length: lineups.data?.length ?? 0 }).map((_, index) => (
-            <SelectItem key={index} value={(index + 1).toString()}>
-              Week {index + 1}
+          {lineups.data?.map((lineup) => (
+            <SelectItem key={lineup.week} value={lineup.week.toString()}>
+              Week {lineup.week}
             </SelectItem>
           ))}
         </SelectContent>


### PR DESCRIPTION
### Motivation
- The lineup view was hard-coded to render weeks 1–6 which prevented week 7 (States) from appearing for leagues that configure that week. 
- The frontend week selector assumed week options by index (`index + 1`) so non-sequential or additional weeks from the API would not display correctly.

### Description
- Updated `GET /api/leagues/<leagueId>/lineups` in `app.py` to validate the `League` exists before querying and return `404` when missing. 
- Changed the backend to pull configured weeks from `WeekStatus` for the league year and iterate over those weeks instead of a hard-coded `range(1, 7)`. 
- Added a fallback that derives the week range from existing `TeamStarted` records when no `WeekStatus` rows exist to maintain backward compatibility. 
- Fixed the frontend week dropdown in `frontend/src/routes/leagues/$leagueId/scores.lazy.tsx` to map API `lineup.week` values directly rather than generating weeks by index, ensuring week 7 (States) appears when present.

### Testing
- Ran `python -m compileall app.py` successfully to verify Python syntax. 
- Ran `npm run -s build` in the `frontend/` directory and completed successfully to verify the frontend changes build without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6a5443c4832696e41e3e8c35bbaa)