### PR TITLE
Include week 7 event assignments on roster pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,7 +600,7 @@ def get_roster_weeks(leagueId):
                         .join(TeamScore, TeamScore.event_key == FRCEvent.event_key)
                         .filter(TeamScore.team_key == frcteam.team_key)
                         .filter(FRCEvent.year == league.year)
-                        .filter(FRCEvent.week < 6)
+                        .filter(FRCEvent.week <= 7)
                         .all()
                     )
 

--- a/frontend/src/routes/leagues/$leagueId/rosters.lazy.tsx
+++ b/frontend/src/routes/leagues/$leagueId/rosters.lazy.tsx
@@ -102,7 +102,7 @@ const RosterWeeksTable = ({
 }) => {
 	if (!rosterWeek) return null;
 
-	const weeks = [1, 2, 3, 4, 6];
+	const weeks = [1, 2, 3, 4, 6, 7];
 
 	return (
 		<Table>
@@ -116,17 +116,17 @@ const RosterWeeksTable = ({
 			</TableHeader>
 			<TableBody>
 				{rosterWeek.roster.map((team) => {
-					const weeklyEvents = Array(5).fill("-");
+					const weeklyEvents = Object.fromEntries(weeks.map((week) => [week, "-"])) as Record<number, string>;
 					team.events.forEach((event) => {
-						if (event.week >= 1 && event.week <= 6) {
-							weeklyEvents[event.week - 1] = event.event_key;
+						if (weeks.includes(event.week)) {
+							weeklyEvents[event.week] = event.event_key;
 						}
 					});
 					return (
 						<TableRow key={team.team_key}>
 							<TableCell>{team.team_key}</TableCell>
-							{weeklyEvents.map((ev, i) => (
-								<TableCell key={i}>{ev}</TableCell>
+							{weeks.map((week) => (
+								<TableCell key={week}>{weeklyEvents[week]}</TableCell>
 							))}
 						</TableRow>
 					);


### PR DESCRIPTION
### Motivation
- Roster detail views were not showing events assigned in week 7 because the backend limited returned events to weeks earlier than 6 and the frontend table was built for a fixed set of weeks. 
- The goal is to return week 7 events from the API and render them in the per-team roster table so users can see week 7 assignments. 

### Description
- Backend: changed the roster weeks query filter from `.filter(FRCEvent.week < 6)` to `.filter(FRCEvent.week <= 7)` so events through week 7 are returned (`app.py`).
- Frontend: added week 7 to the weeks array (`const weeks = [1, 2, 3, 4, 6, 7]`) and updated the table rendering to create a week-keyed map for cells instead of index math (`frontend/src/routes/leagues/$leagueId/rosters.lazy.tsx`).
- Frontend: updated event-to-cell mapping to use explicit week keys and iterated `weeks` for rendering so non-consecutive week lists (e.g., including week 7) map correctly to table columns.

### Testing
- Ran `python -m py_compile app.py` to validate Python syntax and it completed successfully.
- Ran `npm run build` in the `frontend/` directory to verify the TypeScript build and bundling and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6cc2fe148326881db8dafbb1fe6d)