### PR TITLE
Deterministic states (week 7) locked top-3 ranking

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1050,6 +1050,14 @@ class Admin(commands.Cog):
                         )
                     )
                     lockedTeamsRanked = locked_result.scalars().all()
+                    locked_rank_lookup = {
+                        team_id: rank for rank, (team_id, _) in enumerate(lockedTop3)
+                    }
+                    lockedTeamsRanked.sort(
+                        key=lambda score: locked_rank_lookup.get(
+                            score.fantasy_team_id, len(lockedTop3TeamIds)
+                        )
+                    )
 
                     # Assign rank points manually for locked top 3
                     for i, teamscore in enumerate(lockedTeamsRanked):


### PR DESCRIPTION
### Motivation
- The code locked the top-3 teams for States weeks but re-fetched those teams without a defined order, causing the manual `rank_points` (100/75/50) assignments to appear random between runs.

### Description
- After computing the cumulative pre-states standings (`lockedTop3`), add a `locked_rank_lookup` and sort the fetched `lockedTeamsRanked` by that lookup before assigning `rank_points`, ensuring deterministic locked placements.

### Testing
- Ran `python -m compileall cogs/admin.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8230346fc832694c7c4079ea10c8b)