### PR TITLE
Fix offseason event import year type

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -413,7 +413,7 @@ class Admin(commands.Cog):
                 eventKey = str(response["key"])
                 eventName = str(response["name"])
                 week = 99
-                year = eventKey[:4]
+                year = int(response["year"])
                 event_result = await session.execute(
                     select(FRCEvent).where(FRCEvent.event_key == eventKey)
                 )


### PR DESCRIPTION
### Motivation
- The offseason event import stored `year` as a string (derived from `eventKey[:4]`) which caused asyncpg/SQLAlchemy to raise a `DataError` when inserting into the `frcevent.year` `INTEGER` column.

### Description
- Replace `year = eventKey[:4]` with `year = int(response["year"])` in `importSingleEventTask` to ensure `FRCEvent.year` is persisted as an integer.

### Testing
- Ran `python -m py_compile cogs/admin.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed23496ffc83269c5123f4c64cdca4)