### PR TITLE
Add `/autodraft` command to select highest EPA team

### DIFF
--- a/cogs/drafting.py
+++ b/cogs/drafting.py
@@ -702,6 +702,37 @@ class Drafting(commands.Cog):
             interaction=interaction, team_number=team_number, force=False
         )
 
+    @app_commands.command(
+        name="autodraft",
+        description="Automatically draft the highest EPA team currently available.",
+    )
+    async def auto_draft(self, interaction: discord.Interaction):
+        await interaction.response.send_message(
+            "Attempting to auto-draft the highest EPA team.", ephemeral=True
+        )
+        draft: Draft = await self.getDraftFromChannel(interaction=interaction)
+        message = await interaction.original_response()
+        if draft is None:
+            await message.edit(content="No draft associated with this channel.")
+            return
+        league: League = await self.getLeague(draft_id=draft.draft_id)
+        suggestedTeams = await self.getSuggestedTeamsList(
+            eventKey=draft.event_key,
+            year=league.year,
+            isFiM=league.is_fim,
+            draft_id=draft.draft_id,
+            isOffseason=league.offseason,
+        )
+        if len(suggestedTeams) == 0:
+            await message.edit(content="No available teams left to draft.")
+            return
+
+        best_team = suggestedTeams[0][0]
+        await message.edit(content=f"Auto-drafting team {best_team}.")
+        await self.makeDraftPickHandler(
+            interaction=interaction, team_number=best_team, force=False
+        )
+
     """@app_commands.command(name="draftboard", description="Re-post the Draft Board")
   @commands.cooldown(rate=1, per=60)
   async def repost_draft_board(self, interaction: discord.Interaction):


### PR DESCRIPTION
### Motivation
- Provide a one-step command to let a team automatically draft the highest year-end EPA team still available during a draft. 
- Reduce manual selection work while preserving existing draft turn and validation logic.

### Description
- Add an `@app_commands.command` named `autodraft` in `cogs/drafting.py` that exposes the new `/autodraft` slash command. 
- The command resolves the active draft via `getDraftFromChannel`, retrieves candidates using `getSuggestedTeamsList`, picks the top-ranked team, and calls `makeDraftPickHandler(..., force=False)` to perform the pick. 
- The command provides user feedback for missing draft context and for the case when no teams remain to pick. 
- Implementation reuses existing draft-pick validation and ordering logic so existing rules are preserved.

### Testing
- Ran `python -m py_compile cogs/drafting.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24bd6e04883269790b7b8a17b6ccb)